### PR TITLE
Add missing imports in generated visitor

### DIFF
--- a/support/org/intellij/grammar/generator/ParserGenerator.java
+++ b/support/org/intellij/grammar/generator/ParserGenerator.java
@@ -236,9 +236,21 @@ public class ParserGenerator {
     String superIntf = ObjectUtils.notNull(ContainerUtil.getFirstItem(getRootAttribute(myFile, KnownAttribute.IMPLEMENTS)),
                                            KnownAttribute.IMPLEMENTS.getDefaultValue().get(0));
     String shortSuperIntf = StringUtil.getShortName(superIntf);
-    Function<String, String> shortener = generateClassHeader(
-      psiClass, Arrays.asList("org.jetbrains.annotations.*", BnfConstants.PSI_ELEMENT_VISITOR_CLASS, superIntf),
-      "", false, BnfConstants.PSI_ELEMENT_VISITOR_CLASS);
+
+    List<String> imports = new ArrayList<String>(
+        Arrays.asList("org.jetbrains.annotations.*", "com.intellij.psi.StubBasedPsiElement", BnfConstants.PSI_ELEMENT_VISITOR_CLASS, superIntf)
+    );
+
+    for (BnfRule rule : sortedRules.values()) {
+      List<String> ruleImplements = getAttribute(rule, KnownAttribute.IMPLEMENTS);
+      for (String ruleImplement : ruleImplements) {
+        if (!imports.contains(ruleImplement)) {
+          imports.add(ruleImplement);
+        }
+      }
+    }
+
+    Function<String, String> shortener = generateClassHeader(psiClass, imports, "", false, BnfConstants.PSI_ELEMENT_VISITOR_CLASS);
     Set<String> visited = new HashSet<String>();
     Set<String> all = new TreeSet<String>();
     for (String ruleName : sortedRules.keySet()) {


### PR DESCRIPTION
Hi,

This changes add the ability for a rule to implement multiple interfaces at once. This was already supported except for the visitor which did not add the correct imports. This is now fixed.

Ex:

```
implements("my_rule")=["com.intellij.psi.PsiNameIdentifierOwner" "some.other.Interface"]
```

The generated visitor will look like this:

```
import org.jetbrains.annotations.*;
import com.intellij.psi.StubBasedPsiElement;
import com.intellij.psi.PsiElementVisitor;
import com.intellij.psi.PsiNameIdentifierOwner;
import some.other.Interface;

public class MyVisitor extends PsiElementVisitor {
// ...
}
```
