### PR TITLE
Closes #30 - Incorrect error handling when frameName used near EOF.

### DIFF
--- a/support/org/intellij/grammar/parser/GeneratedParserUtilBase.java
+++ b/support/org/intellij/grammar/parser/GeneratedParserUtilBase.java
@@ -201,17 +201,19 @@ public class GeneratedParserUtilBase {
     boolean track = !state.suppressErrors && state.predicateCount < 2 && state.predicateSign;
     if (!track) return nextTokenIsFast(builder_, tokens);
     boolean useFrameName = StringUtil.isNotEmpty(frameName);
-    IElementType tokenType = builder_.getTokenType();
-    if (tokenType == null) return false;
-    boolean result = false;
-    for (IElementType token : tokens) {
-      if (!useFrameName) addVariant(builder_, state, token);
-      result |= tokenType == token;
-    }
     if (useFrameName) {
       addVariantInner(state, builder_.rawTokenIndex(), frameName);
+    } else {
+        for (IElementType token : tokens) {
+            addVariant(builder_, state, token);
+        }
     }
-    return result;
+    IElementType tokenType = builder_.getTokenType();
+    if (tokenType == null) return false;
+    for (IElementType token : tokens) {
+        if (tokenType == token) return true;
+    }
+    return false;
   }
 
   public static boolean nextTokenIs(PsiBuilder builder_, IElementType token) {

--- a/testData/parser/BrokenAttrBeforeEOF.bnf
+++ b/testData/parser/BrokenAttrBeforeEOF.bnf
@@ -1,0 +1,1 @@
+empty ::= id {name=

--- a/testData/parser/BrokenAttrBeforeEOF.txt
+++ b/testData/parser/BrokenAttrBeforeEOF.txt
@@ -1,0 +1,16 @@
+BnfFile:BrokenAttrBeforeEOF.bnf
+  BNF_RULE:empty
+    PsiElement(id)('empty')
+    PsiWhiteSpace(' ')
+    PsiElement(::=)('::=')
+    PsiWhiteSpace(' ')
+    BNF_REFERENCE_OR_TOKEN: id
+      PsiElement(id)('id')
+    PsiWhiteSpace(' ')
+    BNF_ATTRS
+      PsiElement({)('{')
+      BNF_ATTR:name
+        PsiElement(id)('name')
+        PsiElement(=)('=')
+        PsiErrorElement:<literal expression>, '[' or id expected, unexpected end of file
+          <empty list>

--- a/tests/org/intellij/grammar/BnfParserTest.java
+++ b/tests/org/intellij/grammar/BnfParserTest.java
@@ -27,6 +27,7 @@ public class BnfParserTest extends AbstractParsingTestCase {
   public void testAlternativeSyntax() { doTest(true); }
   public void testExternalExpression() { doTest(true); }
   public void testFixes() { doTest(true); }
+  public void testBrokenAttrBeforeEOF() { doTest(true); }
 
   @Override
   protected String loadFile(@NonNls String name) throws IOException {


### PR DESCRIPTION
I added a test case to ensure that proves that all variants if nextTokenIs is used just before EOF.
I'm not 100% sure this solution is the best one but it worked fine for me.
Before the change in the PSI dump <literal expression> was skipped in error message (PsiErrorElement).
