### PR TITLE
Fixed RGH to properly devise accessors

### DIFF
--- a/support/org/intellij/grammar/generator/ParserGenerator.java
+++ b/support/org/intellij/grammar/generator/ParserGenerator.java
@@ -173,7 +173,7 @@ public class ParserGenerator {
       String elementType = getElementType(rule);
       if (StringUtil.isEmpty(elementType)) continue;
       if (sortedCompositeTypes.containsKey(elementType)) continue;
-      if (!Rule.isFake(rule)) {
+      if (!Rule.isFake(rule) || myGraphHelper.isReplacee(rule)) {
         sortedCompositeTypes.put(elementType, rule);
       }
       sortedPsiRules.put(rule.getName(), rule);

--- a/support/org/intellij/grammar/generator/RuleGraphHelper.java
+++ b/support/org/intellij/grammar/generator/RuleGraphHelper.java
@@ -871,6 +871,10 @@ public class RuleGraphHelper {
     return e;
   }
 
+  public boolean isReplacee(BnfRule rule) {
+    return myRuleReplacesMap.containsKey(rule);
+  }
+
   private static boolean isExternalPsi(PsiElement t) {
     return t instanceof LeafPsiElement && ((LeafPsiElement)t).getElementType() == EXTERNAL_TYPE;
   }

--- a/support/org/intellij/grammar/generator/RuleGraphHelper.java
+++ b/support/org/intellij/grammar/generator/RuleGraphHelper.java
@@ -65,6 +65,7 @@ public class RuleGraphHelper {
   };
   private final BnfFile myFile;
   private final MultiMap<BnfRule, BnfRule> myRuleExtendsMap;
+  private final MultiMap<BnfRule, BnfRule> myRuleReplacesMap;
   private final MultiMap<BnfRule, BnfRule> myRulesGraph = newMultiMap();
   private final Map<BnfRule, Map<PsiElement, Cardinality>> myRuleContentsMap = ContainerUtil.newTroveMap();
   private final MultiMap<BnfRule, PsiElement> myRulesCollapseMap = newMultiMap();
@@ -176,6 +177,18 @@ public class RuleGraphHelper {
     return ruleExtendsMap;
   }
 
+  public static MultiMap<BnfRule, BnfRule> buildRuleReplacementMap(BnfFile file) {
+    MultiMap<BnfRule, BnfRule> ruleReplacedElementTypesMap = newMultiMap();
+    for (BnfRule rule : file.getRules()) {
+      if (Rule.isPrivate(rule) || Rule.isExternal(rule)) continue;
+      BnfRule target = getSynonymTargetOrSelf(rule);
+      if (target != rule) {
+        ruleReplacedElementTypesMap.putValue(target, rule);
+      }
+    }
+    return ruleReplacedElementTypesMap;
+  }
+
   private static <K, V> MultiMap<K, V> newMultiMap() {
     return new MultiMap<K, V>() {
       @NotNull
@@ -229,12 +242,13 @@ public class RuleGraphHelper {
   }
 
   public RuleGraphHelper(BnfFile file) {
-    this(file, buildExtendsMap(file));
+    this(file, buildExtendsMap(file), buildRuleReplacementMap(file));
   }
 
-  public RuleGraphHelper(BnfFile file, MultiMap<BnfRule, BnfRule> ruleExtendsMap) {
+  public RuleGraphHelper(BnfFile file, MultiMap<BnfRule, BnfRule> ruleExtendsMap, MultiMap<BnfRule, BnfRule> ruleReplacesMap) {
     myFile = file;
     myRuleExtendsMap = ruleExtendsMap;
+    myRuleReplacesMap = ruleReplacesMap;
 
     buildRulesGraph();
     buildCollapseMap();
@@ -296,6 +310,18 @@ public class RuleGraphHelper {
       return result;
     }
     result.remove(NOT_EMPTY_MARKER); // todo private rules should retain this
+
+    // Try coalesce accessors across the rules, which `elementType` being reset
+    // to this particular one, therefore adding new accessors to the synonym-rule
+    // _or_ relaxing existing constraints (@NotNull -> @Nullable), etc.
+    if (myRuleReplacesMap.containsKey(rule)) {
+      for (BnfRule proto : myRuleReplacesMap.get(rule)) {
+        Map<PsiElement, Cardinality> protoContent = myRuleContentsMap.get(proto);
+        if (protoContent != null)
+          result = joinMaps(rule, false, BnfTypes.BNF_CHOICE, Arrays.asList(result, protoContent));
+      }
+    }
+
     myRuleContentsMap.put(rule, result);
     return result;
   }


### PR DESCRIPTION
Fixed `RuleGraphHelper` to properly devise accessors as union of accessors of rules being synonymized  by this particular one, relaxing (if needed) constraints on some of them (for ex. reducing cardinality and therefore annotations from `@NotNull` to `@Nullable`, etc.)