### PR TITLE
Don't suppress psiClass-prefix/suffix application for coincidentally matching rule names

### DIFF
--- a/support/org/intellij/grammar/generator/ParserGeneratorUtil.java
+++ b/support/org/intellij/grammar/generator/ParserGeneratorUtil.java
@@ -798,9 +798,9 @@ public class ParserGeneratorUtil {
     }
 
     public String apply(String s) {
-      int extraCapacity = prefix == null ? suffix.length() : suffix == null ? prefix.length() : prefix.length() + suffix.length();
-      if (extraCapacity == 0) return s;
-      StringBuilder sb = new StringBuilder(s.length() + extraCapacity);
+      int extraCharCount = prefix == null ? suffix.length() : suffix == null ? prefix.length() : prefix.length() + suffix.length();
+      if (extraCharCount == 0) return s;
+      StringBuilder sb = new StringBuilder(s.length() + extraCharCount);
       if (prefix != null) sb.append(prefix);
       sb.append(s);
       if (suffix != null) sb.append(suffix);

--- a/support/org/intellij/grammar/generator/ParserGeneratorUtil.java
+++ b/support/org/intellij/grammar/generator/ParserGeneratorUtil.java
@@ -269,7 +269,7 @@ public class ParserGeneratorUtil {
       if (cas == Case.CAMEL && i < len - 1 && !strings[i+1].startsWith("_") && Case.UPPER.apply(s).equals(s)) sb.append(s);
       else sb.append(cas.apply(s));
     }
-    return format == null ? sb.toString() : format.enforce(sb.toString());
+    return format == null ? sb.toString() : format.apply(sb.toString());
   }
 
   public static String getPsiPackage(BnfFile file) {
@@ -795,6 +795,16 @@ public class ParserGeneratorUtil {
       JBIterable<String> parts = JBIterable.of(format == null ? null : format.split("/"));
       prefix = parts.get(0);
       suffix = StringUtil.join(parts.skip(1), "");
+    }
+
+    public String apply(String s) {
+      int extraCapacity = prefix == null ? suffix.length() : suffix == null ? prefix.length() : prefix.length() + suffix.length();
+      if (extraCapacity == 0) return s;
+      StringBuilder sb = new StringBuilder(s.length() + extraCapacity);
+      if (prefix != null) sb.append(prefix);
+      sb.append(s);
+      if (suffix != null) sb.append(suffix);
+      return sb.toString();
     }
 
     public String enforce(String s) {

--- a/tests/org/intellij/grammar/BnfUtilTest.java
+++ b/tests/org/intellij/grammar/BnfUtilTest.java
@@ -29,6 +29,12 @@ public class BnfUtilTest extends UsefulTestCase {
   public void testIdentifiers() {
     assertEquals("AbcEdf", toIdentifier("abc-edf", Case.CAMEL));
     assertEquals("SampleAbcEdfElement", toIdentifier("abc-edf", "Sample/Element", Case.CAMEL));
+
+    // w/ a single-letter psiClass-prefix coincidentally matching the 1st letter of name being transformed
+    assertEquals("CContinueStatementElement", toIdentifier("continue-statement", "C/Element", Case.CAMEL));
+    // w/ a psiClass-suffix that matches the rule name suffix but has a different meaning & context and should be preserved
+    assertEquals("HtmlBodyElementElement", toIdentifier("body-element", "Html/Element", Case.CAMEL));
+
     assertEquals("getAbcEdf", getGetterName("abc-edf"));
     assertEquals("getMySomething", getGetterName("MY_SOMETHING"));
     assertEquals("getWithSpace", getGetterName("with space"));


### PR DESCRIPTION
*ahem*-- some of us are working on way more c00ler languages w/ single-letter names :P