### PR TITLE
Java language injection into JFlex

### DIFF
--- a/gen/org/intellij/jflex/psi/impl/JFlexJavaCodeImpl.java
+++ b/gen/org/intellij/jflex/psi/impl/JFlexJavaCodeImpl.java
@@ -26,7 +26,7 @@ import org.intellij.jflex.psi.*;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.tree.IElementType;
 
-public class JFlexJavaCodeImpl extends JFlexCompositeImpl implements JFlexJavaCode {
+public class JFlexJavaCodeImpl extends JFlexJavaCodeInjectedImpl implements JFlexJavaCode {
 
   public JFlexJavaCodeImpl(IElementType type) {
     super(type);

--- a/grammars/JFlex.bnf
+++ b/grammars/JFlex.bnf
@@ -126,6 +126,7 @@
   name(".*_expression")="expression"
   name("option.*")="option"
   name("char_class_.*|char_range")="char"
+  mixin("java_code")="org.intellij.jflex.psi.impl.JFlexJavaCodeInjectedImpl"
 
 }
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -110,6 +110,7 @@
     <lang.braceMatcher language="JFlex" implementationClass="org.intellij.jflex.editor.JFlexBraceMatcher"/>
     <quoteHandler fileType="JFlex" className="org.intellij.jflex.editor.JFlexQuoteHandler"/>
     <lang.psiStructureViewFactory language="JFlex" implementationClass="org.intellij.jflex.editor.JFlexStructureViewFactory"/>
+    <languageInjector implementation="org.intellij.jflex.injection.JFlexJavaInjector" />
 
   </extensions>
   <actions>

--- a/src/org/intellij/jflex/injection/EmbeddedJavaLiteralTextEscaper.java
+++ b/src/org/intellij/jflex/injection/EmbeddedJavaLiteralTextEscaper.java
@@ -1,0 +1,38 @@
+package org.intellij.jflex.injection;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.LiteralTextEscaper;
+import org.intellij.jflex.psi.JFlexJavaCodeInjected;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: Max
+ * Date: 15.03.2008
+ * Time: 21:01:02
+ */
+public class EmbeddedJavaLiteralTextEscaper extends LiteralTextEscaper<JFlexJavaCodeInjected> {
+
+    public EmbeddedJavaLiteralTextEscaper(@NotNull JFlexJavaCodeInjected host) {
+        super(host);
+    }
+
+    public boolean decode(@NotNull TextRange textrange, @NotNull StringBuilder stringbuilder) {
+        stringbuilder.append(myHost.getText(), textrange.getStartOffset(), textrange.getEndOffset());
+        return true;
+    }
+
+    public int getOffsetInHost(int i, @NotNull TextRange textrange) {
+        int j = i + textrange.getStartOffset();
+        if (j < textrange.getStartOffset())
+            j = textrange.getStartOffset();
+        if (j > textrange.getEndOffset())
+            j = textrange.getEndOffset();
+        return j;
+    }
+
+    public boolean isOneLine() {
+        return false;
+    }
+
+}

--- a/src/org/intellij/jflex/injection/JFlexJavaInjector.java
+++ b/src/org/intellij/jflex/injection/JFlexJavaInjector.java
@@ -1,0 +1,92 @@
+package org.intellij.jflex.injection;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.lang.StdLanguages;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.InjectedLanguagePlaces;
+import com.intellij.psi.LanguageInjector;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.TokenSet;
+import org.intellij.jflex.psi.*;
+import org.intellij.jflex.psi.impl.JFlexFile;
+import org.jetbrains.annotations.NotNull;
+
+public class JFlexJavaInjector implements LanguageInjector {
+
+    public static final String DEFCLASS = "Yylex";
+    public static final String DEFTYPE = "int";
+
+    public void getLanguagesToInject(@NotNull PsiLanguageInjectionHost _host, @NotNull InjectedLanguagePlaces registrar) {
+
+        if (!(_host instanceof JFlexJavaCodeInjected)) return;
+
+        JFlexJavaCodeInjected host = (JFlexJavaCodeInjected) _host;
+
+        assert host.getContainingFile() instanceof JFlexFile;
+        JFlexFile file = (JFlexFile) host.getContainingFile();
+
+        JFlexJavaCodeInjected importSection = null;
+        ASTNode user_code_sec = file.getNode().findChildByType(JFlexTypes.FLEX_USER_CODE_SECTION);
+        if (user_code_sec != null) {
+            importSection = (JFlexJavaCodeInjected) user_code_sec.findChildByType(JFlexTypes.FLEX_JAVA_CODE).getPsi();
+        }
+        //processing imports and package section
+        if (host == importSection) {
+            registrar.addPlace(StdLanguages.JAVA, new TextRange(0, host.getTextLength()), null, "\npublic class a{}");
+            return;
+        }
+
+        //let's add some imports and package statements from flex file header
+        StringBuilder prefix = new StringBuilder();
+
+        if (importSection != null) {
+            prefix.append(importSection.getText());
+        }
+
+        String classnamestr = getJavaOptions(file, JFlexTypes.FLEX_OPT_CLASS, DEFCLASS);
+
+        String returntypestr = getJavaOptions(file, JFlexTypes.FLEX_OPT_TYPE, DEFTYPE);
+
+        String implementedstr = getJavaOptions(file, JFlexTypes.FLEX_OPT_IMPLEMENTS, "");
+        if (implementedstr.length() !=0 ) {
+            implementedstr=" implements " + implementedstr;
+        }
+
+        prefix.append("\npublic class ").append(classnamestr).append(implementedstr).append("{");
+
+        StringBuilder suffix = new StringBuilder();
+
+        if (host.isMatchAction()) {
+            prefix.append("public ").append(returntypestr).append(" yylex(){");
+            suffix.append("}}");
+        } else {
+            suffix.append("}");
+        }
+
+        registrar.addPlace(StdLanguages.JAVA, new TextRange(0, host.getTextLength()), prefix.toString(), suffix.toString());
+    }
+
+    private String getJavaOptions(@NotNull JFlexFile file,@NotNull IElementType option_type, String defaultVal) {
+        StringBuilder result = new StringBuilder();
+
+        ASTNode dec_section = file.getNode().findChildByType(JFlexTypes.FLEX_DECLARATIONS_SECTION);
+        if (dec_section != null) {
+            for (ASTNode flex_option : dec_section.getChildren(TokenSet.create(JFlexTypes.FLEX_OPTION))) {
+                if (flex_option.findChildByType( option_type ) != null) {
+                    ASTNode[] nodes = flex_option.getChildren(TokenSet.create(JFlexTypes.FLEX_JAVA_TYPE));
+                    for (ASTNode flex_java_type : nodes) {
+                        result.append( flex_java_type.findChildByType(JFlexTypes.FLEX_ID).getPsi().getText());
+                        if (flex_java_type != nodes[nodes.length-1]) {
+                            result.append(",");
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        return result.length()==0 ? defaultVal : result.toString();
+    }
+
+
+}

--- a/src/org/intellij/jflex/psi/JFlexJavaCodeInjected.java
+++ b/src/org/intellij/jflex/psi/JFlexJavaCodeInjected.java
@@ -1,0 +1,16 @@
+package org.intellij.jflex.psi;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: Max
+ * Date: 15.03.2008
+ * Time: 18:52:38
+ */
+public interface JFlexJavaCodeInjected extends JFlexComposite, PsiLanguageInjectionHost {
+
+    boolean isMatchAction();
+
+}

--- a/src/org/intellij/jflex/psi/impl/JFlexJavaCodeInjectedImpl.java
+++ b/src/org/intellij/jflex/psi/impl/JFlexJavaCodeInjectedImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2011-present Greg Shrago
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.intellij.jflex.psi.impl;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.LiteralTextEscaper;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import com.intellij.psi.tree.IElementType;
+import org.intellij.jflex.psi.JFlexJavaCodeInjected;
+import org.intellij.jflex.psi.JFlexTypes;
+import org.intellij.jflex.injection.EmbeddedJavaLiteralTextEscaper;
+import org.jetbrains.annotations.NotNull;
+
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: Max
+ * Date: 15.03.2008
+ * Time: 18:51:14
+ */
+public class JFlexJavaCodeInjectedImpl extends JFlexCompositeImpl implements JFlexJavaCodeInjected {
+
+    public JFlexJavaCodeInjectedImpl(IElementType type) {
+        super(type);
+    }
+
+    @Override
+    public boolean isValidHost() {
+        return true;
+    }
+
+    public boolean isMatchAction() {
+        ASTNode prev = getNode().getTreePrev();
+        return prev != null && prev.getElementType() == JFlexTypes.FLEX_BRACE1;
+    }
+
+    public PsiLanguageInjectionHost updateText(@NotNull String text) {
+        return this;
+    }
+
+    @NotNull
+    public LiteralTextEscaper<JFlexJavaCodeInjected> createLiteralTextEscaper() {
+        return new EmbeddedJavaLiteralTextEscaper(this);
+    }
+}


### PR DESCRIPTION
It's a draft but working version of Java language injection into JFlex. It's actually a quick code porting from abandoned [JFlex Support](https://github.com/jflex-de/idea-jflex) plugin.

@gregsh please have a look and lets me know if it has any sense to continue. If Yes, would be nice to have some ideas what to fix and improve, from your core developer and maintainer of Grammar-kit point of view.

PS Personally, I'm missing IDE support for Java parts in .flex when developing my CMake plugin.

![screenshot from 2017-12-03 00-14-27crop](https://user-images.githubusercontent.com/14268320/33522634-3d73d3e6-d7bf-11e7-8a34-acb16e4efd46.png)
