### PR TITLE
Upgrade to IntelliJ 2018.3.3

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="ProjectResources">
     <default-html-doctype>http://www.w3.org/1999/xhtml</default-html-doctype>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="IntelliJ IDEA IU-171.4424.56" project-jdk-type="IDEA JDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="IntelliJ IDEA IU-183.5153.38" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2018.3
+
+* Update artifacts to be based on IntelliJ IDEA 2018.3.
+
 2017.1.7
 
 * GPUB: extract extend_marker_impl and improve error elements handling

--- a/binaries/light-psi-all-licenses/automaton_license.txt
+++ b/binaries/light-psi-all-licenses/automaton_license.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2001-2017 Anders Moeller
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,9 +18,9 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-version=2017.1.8-SNAPSHOT
+version=2018.3-SNAPSHOT
 
-ideaVersion=2017.1
+ideaVersion=2018.3.3
 javaVersion=1.8
 
 artifactsPath=build/artifacts

--- a/resources/META-INF/MANIFEST.MF
+++ b/resources/META-INF/MANIFEST.MF
@@ -1,16 +1,15 @@
 Manifest-Version: 1.0
 Main-Class: org.intellij.grammar.Main
 Class-Path: light-psi-all.jar   
- lib/annotations.jar     
- lib/asm-all.jar
- lib/automaton.jar     
+ lib/annotations.jar
+ lib/asm-all-7.0.jar
+ lib/automaton-1.12-1.jar
  lib/extensions.jar
- lib/guava-19.0.jar
+ lib/guava-25.1-jre.jar
  lib/idea.jar
- lib/jdom.jar
- lib/junit.jar
- lib/openapi.jar  
- lib/picocontainer.jar
+ lib/picocontainer-1.2.jar
+ lib/platform-api.jar
+ lib/platform-impl.jar
  lib/trove4j.jar
  lib/util.jar
 

--- a/resources/META-INF/MANIFEST.MF
+++ b/resources/META-INF/MANIFEST.MF
@@ -1,7 +1,16 @@
 Manifest-Version: 1.0
 Main-Class: org.intellij.grammar.Main
 Class-Path: light-psi-all.jar   
- lib/jdom.jar lib/trove4j.jar lib/junit.jar lib/guava-19.0.jar lib/asm-all.jar lib/automaton.jar     
- lib/util.jar  lib/annotations.jar     
- lib/picocontainer.jar lib/extensions.jar lib/idea.jar lib/openapi.jar  
+ lib/annotations.jar     
+ lib/asm-all.jar
+ lib/automaton.jar     
+ lib/extensions.jar
+ lib/guava-19.0.jar
+ lib/idea.jar
+ lib/jdom.jar
+ lib/junit.jar
+ lib/openapi.jar  
+ lib/picocontainer.jar
+ lib/trove4j.jar
+ lib/util.jar
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,8 +1,8 @@
 <idea-plugin url="https://github.com/JetBrains/Grammar-Kit">
   <id>org.jetbrains.idea.grammar</id>
-  <version>2017.1.8-SNAPSHOT</version>
+  <version>2018.3-SNAPSHOT</version>
   <vendor email="gregory.shrago@jetbrains.com">Greg Shrago</vendor>
-  <idea-version since-build="171"/>
+  <idea-version since-build="183"/>
 
   <name>Grammar-Kit</name>
   <description>BNF Grammars and JFlex lexers editor. Readable parser/PSI code generator.</description>

--- a/src/org/intellij/grammar/psi/BnfAttrPatternRefSearcher.java
+++ b/src/org/intellij/grammar/psi/BnfAttrPatternRefSearcher.java
@@ -36,7 +36,7 @@ public class BnfAttrPatternRefSearcher extends QueryExecutorBase<PsiReference, R
   }
 
   @Override
-  public void processQuery(@NotNull ReferencesSearch.SearchParameters queryParameters, @NotNull final Processor<PsiReference> consumer) {
+  public void processQuery(@NotNull ReferencesSearch.SearchParameters queryParameters, @NotNull final Processor<? super PsiReference> consumer) {
     final PsiElement target = queryParameters.getElementToSearch();
     if (!(target instanceof BnfRule)) return;
 

--- a/src/org/intellij/jflex/psi/impl/JFlexStateUsageSearcher.java
+++ b/src/org/intellij/jflex/psi/impl/JFlexStateUsageSearcher.java
@@ -42,7 +42,7 @@ public class JFlexStateUsageSearcher extends QueryExecutorBase<PsiReference, Ref
   }
 
   @Override
-  public void processQuery(@NotNull ReferencesSearch.SearchParameters queryParameters, @NotNull Processor<PsiReference> consumer) {
+  public void processQuery(@NotNull ReferencesSearch.SearchParameters queryParameters, @NotNull Processor<? super PsiReference> consumer) {
     PsiElement element = queryParameters.getElementToSearch();
     PsiFile containingFile = element.getContainingFile();
     if (element instanceof PsiField) {


### PR DESCRIPTION
Between IntelliJ 2017.1 and 2018.3, there have been some minor changes in classes that are included in `light-psi-all.jar` that are not reflected in the GrammarKit distribution.  Examples:

(1)  The signature of `com.intellij.openapi.application.QueryExecutorBase` changed in https://github.com/JetBrains/intellij-community/commit/aaed1ccb910f6f4a9ea2f96894d99b6e35a59ef9 .
(2) The signature of `com.intellij.lang.ParserDefinition` changed in https://github.com/JetBrains/intellij-community/commit/5e8e3a4ddaf66aed2ba28a33ca606ff16a1587bb#diff-89aef8b91fee96d99d610ef8443129b5 so that if one builds with `light-psi-all.jar` and targets 2018.3, one cannot fix the `@Deprecation` warnings and use the `@Override` tag correctly.

Also, between 2017.1 and 2018.3, IntelliJ dependencies moved between jar files, so this updates `LightPsi` to be more forgiving about where it collects classes from.

