### PR TITLE
Fix NullPointerException with 2019.3 platform

### DIFF
--- a/src/org/intellij/grammar/LightPsi.java
+++ b/src/org/intellij/grammar/LightPsi.java
@@ -285,6 +285,15 @@ public class LightPsi {
       Extensions.registerAreaClass("IDEA_PROJECT", null);
       MutablePicoContainer appContainer = application.getPicoContainer();
       MockProject project = new MockProject(appContainer, rootDisposable);
+      try {
+        // Starting from 2019.3 MessageBusFactory is application service with MessageBusFactoryImpl implementation.
+        // So we have to register it too
+        Class messageBusFactoryImplClass = Class.forName("com.intellij.util.messages.impl.MessageBusFactoryImpl");
+        registerApplicationService(project, MessageBusFactory.class, messageBusFactoryImplClass);
+      }
+      catch (ClassNotFoundException e) {
+        System.out.println("MessageBusFactoryImpl class is not found");
+      }
       registerComponentInstance(appContainer, MessageBus.class, MessageBusFactory.newMessageBus(application));
       final MockEditorFactory editorFactory = new MockEditorFactory();
       registerComponentInstance(appContainer, EditorFactory.class, editorFactory);


### PR DESCRIPTION
Starting from 2019.3 `MessageBusFactory` is application service with `MessageBusFactoryImpl` implementation class.
So, we have to register it to avoid NPE while executing `MessageBusFactory.newMessageBus(application)` [code](https://github.com/JetBrains/Grammar-Kit/blob/1694755d7c74f8aba5af62aa836b923ec2def8ac/src/org/intellij/grammar/LightPsi.java#L288)

Fixes #215