### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/org/intellij/grammar/generator/RuleGraphHelper.java
+++ b/src/org/intellij/grammar/generator/RuleGraphHelper.java
@@ -708,7 +708,7 @@ public class RuleGraphHelper {
 
   private boolean collectSynonymsAndCollapseAlternatives(Map<BnfRule, BnfRule> rulesAndAlts) {
     boolean hasSynonyms = false;
-    for (Map.Entry<BnfRule, BnfRule> e : ContainerUtil.newArrayList(rulesAndAlts.entrySet())) {
+    for (Map.Entry<BnfRule, BnfRule> e : new ArrayList<>(rulesAndAlts.entrySet())) {
       BnfRule rule = e.getKey();
       e.setValue(getSynonymTargetOrSelf(rule));
       hasSynonyms |= rule != e.getValue();


### PR DESCRIPTION
I see this warning a lot:

```
WARN: This method in class com.intellij.util.containers.ContainerUtil is deprecated and going to be removed soon. Use `new ArrayList(Collection)` instead. class java.util.LinkedHashMap$LinkedEntrySet
com.intellij.util.DeprecatedMethodException: This method in class com.intellij.util.containers.ContainerUtil is deprecated and going to be removed soon. Use `new ArrayList(Collection)` instead. class java.util.LinkedHashMap$LinkedEntrySet
	at com.intellij.util.DeprecatedMethodException.report(DeprecatedMethodException.java:21)
	at com.intellij.util.containers.ContainerUtil.newArrayList(ContainerUtil.java:225)
	at org.intellij.grammar.generator.RuleGraphHelper.collectSynonymsAndCollapseAlternatives(RuleGraphHelper.java:711)
	at org.intellij.grammar.generator.RuleGraphHelper.compactInheritors(RuleGraphHelper.java:684)
	at org.intellij.grammar.generator.RuleGraphHelper.joinMaps(RuleGraphHelper.java:530)
	at org.intellij.grammar.generator.RuleGraphHelper.collectMembersInner(RuleGraphHelper.java:474)
	at org.intellij.grammar.generator.RuleGraphHelper.collectMembers(RuleGraphHelper.java:374)
	at org.intellij.grammar.generator.RuleGraphHelper.collectMembers(RuleGraphHelper.java:294)
	at org.intellij.grammar.generator.RuleGraphHelper.buildContentsMap(RuleGraphHelper.java:282)
	at org.intellij.grammar.generator.RuleGraphHelper.<init>(RuleGraphHelper.java:238)
	at org.intellij.grammar.generator.RuleGraphHelper.<init>(RuleGraphHelper.java:229)
	at org.intellij.grammar.generator.RuleGraphHelper.lambda$getCached$2(RuleGraphHelper.java:223)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:54)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$1(CachedValueBase.java:240)
	at com.intellij.openapi.util.RecursionManager$1.doPreventingRecursion(RecursionManager.java:113)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:71)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:241)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:43)
	at org.intellij.grammar.generator.RuleGraphHelper.getCached(RuleGraphHelper.java:225)
	at org.intellij.grammar.generator.ParserGenerator.<init>(ParserGenerator.java:200)
	at org.intellij.grammar.Main.main(Main.java:85)
```

Here's a fix. I still don't understand why aren't you just traversing through the set, though. Is this relevant to the order of traversal? But since it was a set, it's already unordered.