### PR TITLE
add a force cast for visitElement functions' parameter.

### DIFF
--- a/src/org/intellij/grammar/generator/ParserGenerator.java
+++ b/src/org/intellij/grammar/generator/ParserGenerator.java
@@ -502,7 +502,7 @@ public class ParserGenerator {
       }
       else {
         String superPrefix = methodName.equals("Element") ? "super." : "";
-        out(superPrefix + "visitElement(o);");
+        out(superPrefix + "visitElement((" + PSI_ELEMENT_CLASS + ") o);");
         if (G.visitorValue != null) out(ret + "null;");
       }
       out("}");


### PR DESCRIPTION
Sometimes we must add it manually due to the current mechanism.
And I do believe such change will harm nothing.

----------

I meet this when I try to product my plugin.
more information:
plugin : https://github.com/XenoAmess/x8l_idea_plugin
bnf : https://github.com/XenoAmess/x8l_idea_plugin/blob/master/src/main/java/com/xenoamess/x8l/psi/X8l.bnf#L72
visitor needed add force cast line: https://github.com/XenoAmess/x8l_idea_plugin/blob/master/src/main/gen/com/xenoamess/x8l/psi/X8lVisitor.java#L69
