### PR TITLE
Improve error messages from methods attribute

### DIFF
--- a/src/org/intellij/grammar/generator/RuleMethodsHelper.java
+++ b/src/org/intellij/grammar/generator/RuleMethodsHelper.java
@@ -78,6 +78,11 @@ public class RuleMethodsHelper {
     return myMethods.get(rule).first.get(name);
   }
 
+  @Nullable
+  public Collection<String> getAvailableMethodInfo(BnfRule rule) {
+    return myMethods.get(rule).first.keySet();
+  }
+
   protected void calcMethods(BnfRule rule, Map<String, String> tokensReversed) {
     List<MethodInfo> result = new ArrayList<>();
 


### PR DESCRIPTION
Currently any problem in the methods attribute returns generic error message along the lines of `incorrect item 'foo' in 'Element' method bar="baz"`, without any explanation of what went wrong. This, combined with the fact that there is very little documentation (that I could find at least), makes it hard to develop new grammars and to learn how the whole thing works.

I had to refactor the code a bit to be able to improve the error message, but the functionality should be the same (except for slightly more validation, mentioned below). I don't have much experience with this tool, so the code may not be ideal and some of the error messages may be incomplete or even incorrect (especially the `references empty rule`-one), but I think that it is still an improvement - at least it helped me to figure out my problems.

**Technical details:**  
`resolveUserPsiPathMethods` is a copy of an existing function of the same name (and different signature) which is defined just above the diff. The previous method returned iterable of `null`, `String` and `RuleMethodsHelper.MethodInfo`, which all meant different things. I have modified this to return only a single type that contains all necessary information.

The method was used in two places - in `generateUserPsiAccessors`, which is important for this change, and in `getRuleMethodTypesToImport` (above in the same file), which I haven't touched, because I don't understand what it does. Somebody who knows can decide whether it is a good idea to remove the old method and use the new one in both places or not.

The new version of `resolveUserPsiPathMethods` is longer than the old one, because it is a bit stricter on its input (I haven't tested it, but the old version seems to allow paths like *"foo[1]bar"*, ignoring the *bar* part), does index parsing and validation, which was previously handled partially in two places, and finally because it generates the errors.