### PR TITLE
Update outdated class name

### DIFF
--- a/resources/messages/attributeDescriptions/hooks.html
+++ b/resources/messages/attributeDescriptions/hooks.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 Custom rule parsing hooks, e.g. whitespace binders. A hook is a piece of code that implements
-<code>org.intellij.grammar.parser.GeneratedParserUtilBase.SectionHook</code> interface
+<code>org.intellij.grammar.parser.GeneratedParserUtilBase.Hook</code> interface
 
 <h2>Examples:</h2>
 <pre><code>


### PR DESCRIPTION
- `SectionHook` was renamed to `Hook`