### PR TITLE
Add attribute `mixedAST` to simplify mixed AST+PSI creation

### DIFF
--- a/resources/messages/attributeDescriptions/mixedAST.html
+++ b/resources/messages/attributeDescriptions/mixedAST.html
@@ -1,0 +1,15 @@
+<html>
+<body>
+Generate mixed PSI+AST implementation. Such implementations usually extend
+`com.intellij.psi.impl.source.tree.CompositePsiElement` class.
+
+<h2>Examples:</h2>
+<pre><code>
+  {
+    mixedAST = true
+  }
+  my_named ::=
+</code></pre>
+
+</body>
+</html>

--- a/src/org/intellij/grammar/KnownAttribute.java
+++ b/src/org/intellij/grammar/KnownAttribute.java
@@ -58,6 +58,7 @@ public class KnownAttribute<T> {
   public static final KnownAttribute<String>       MIXIN                     = create(false, String.class, "mixin", null);
   public static final KnownAttribute<String>       RECOVER_WHILE             = create(false, String.class, "recoverWhile", null);
   public static final KnownAttribute<String>       NAME                      = create(false, String.class, "name", null);
+  public static final KnownAttribute<Boolean>      MIXED_AST                 = create(false, Boolean.class, "mixedAST", false);
 
   public static final KnownAttribute<Boolean>      EXTRA_ROOT                = create(false, Boolean.class, "extraRoot", false);
   public static final KnownAttribute<Boolean>      RIGHT_ASSOCIATIVE         = create(false, Boolean.class, "rightAssociative", false);

--- a/testData/generator/MixedAST.PSI.expected.java
+++ b/testData/generator/MixedAST.PSI.expected.java
@@ -1,0 +1,228 @@
+// ---- FooTypes.java -----------------
+//header.txt
+package test;
+
+import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.PsiElement;
+import com.intellij.lang.ASTNode;
+import test.psi.impl.*;
+import com.intellij.psi.impl.source.tree.CompositePsiElement;
+
+public interface FooTypes {
+
+  IElementType ELEMENT_1 = FooParserDefinition.createType("ELEMENT_1");
+  IElementType ELEMENT_2 = FooParserDefinition.createType("ELEMENT_2");
+  IElementType ELEMENT_3 = FooParserDefinition.createType("ELEMENT_3");
+
+  IElementType AA = FooParserDefinition.createTokenType("aa");
+  IElementType BB = FooParserDefinition.createTokenType("bb");
+
+  class Factory {
+    public static PsiElement createElement(ASTNode node) {
+      IElementType type = node.getElementType();
+      if (type == ELEMENT_2) {
+        return new Element2Impl(node);
+      }
+      else if (type == ELEMENT_3) {
+        return new Element3Impl(node);
+      }
+      throw new AssertionError("Unknown element type: " + type);
+    }
+
+    public static CompositePsiElement createElement(IElementType type) {
+       if (type == ELEMENT_1) {
+        return new Element1Impl(type);
+      }
+      throw new AssertionError("Unknown element type: " + type);
+    }
+  }
+}
+// ---- Element1.java -----------------
+//header.txt
+package test.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+
+public interface Element1 extends PsiElement {
+
+  @NotNull
+  PsiElement getAa();
+
+}
+// ---- Element2.java -----------------
+//header.txt
+package test.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+
+public interface Element2 extends PsiElement {
+
+  @NotNull
+  PsiElement getBb();
+
+}
+// ---- Element3.java -----------------
+//header.txt
+package test.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.StubBasedPsiElement;
+import test.stub.Element3Stub;
+
+public interface Element3 extends PsiElement, StubBasedPsiElement<Element3Stub> {
+
+  @NotNull
+  PsiElement getBb();
+
+}
+// ---- Element1Impl.java -----------------
+//header.txt
+package test.psi.impl;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import test.psi.MyPsiTreeUtil;
+import static test.FooTypes.*;
+import test.CompositePsiElementImpl;
+import test.psi.*;
+import com.intellij.psi.tree.IElementType;
+
+public class Element1Impl extends CompositePsiElementImpl implements Element1 {
+
+  public Element1Impl(IElementType type) {
+    super(type);
+  }
+
+  public void accept(@NotNull Visitor visitor) {
+    visitor.visitElement1(this);
+  }
+
+  @Override
+  public void accept(@NotNull PsiElementVisitor visitor) {
+    if (visitor instanceof Visitor) accept((Visitor)visitor);
+    else super.accept(visitor);
+  }
+
+  @Override
+  @NotNull
+  public PsiElement getAa() {
+    return findPsiChildByType(AA);
+  }
+
+}
+// ---- Element2Impl.java -----------------
+//header.txt
+package test.psi.impl;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import test.psi.MyPsiTreeUtil;
+import static test.FooTypes.*;
+import test.AstDelegatedPsiElementImpl;
+import test.psi.*;
+
+public class Element2Impl extends AstDelegatedPsiElementImpl implements Element2 {
+
+  public Element2Impl(ASTNode node) {
+    super(node);
+  }
+
+  public void accept(@NotNull Visitor visitor) {
+    visitor.visitElement2(this);
+  }
+
+  @Override
+  public void accept(@NotNull PsiElementVisitor visitor) {
+    if (visitor instanceof Visitor) accept((Visitor)visitor);
+    else super.accept(visitor);
+  }
+
+  @Override
+  @NotNull
+  public PsiElement getBb() {
+    return notNullChild(findChildByType(BB));
+  }
+
+}
+// ---- Element3Impl.java -----------------
+//header.txt
+package test.psi.impl;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import test.psi.MyPsiTreeUtil;
+import static test.FooTypes.*;
+import test.StubBasedPsiElementImpl;
+import test.stub.Element3Stub;
+import test.psi.*;
+import com.intellij.psi.stubs.IStubElementType;
+
+public class Element3Impl extends StubBasedPsiElementImpl<Element3Stub> implements Element3 {
+
+  public Element3Impl(ASTNode node) {
+    super(node);
+  }
+
+  public Element3Impl(Element3Stub stub, IStubElementType stubType) {
+    super(stub, stubType);
+  }
+
+  public void accept(@NotNull Visitor visitor) {
+    visitor.visitElement3(this);
+  }
+
+  @Override
+  public void accept(@NotNull PsiElementVisitor visitor) {
+    if (visitor instanceof Visitor) accept((Visitor)visitor);
+    else super.accept(visitor);
+  }
+
+  @Override
+  @NotNull
+  public PsiElement getBb() {
+    return notNullChild(findChildByType(BB));
+  }
+
+}
+// ---- Visitor.java -----------------
+//header.txt
+package test.psi;
+
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.PsiElement;
+
+public class Visitor extends PsiElementVisitor {
+
+  public void visitElement1(@NotNull Element1 o) {
+    visitPsiElement(o);
+  }
+
+  public void visitElement2(@NotNull Element2 o) {
+    visitPsiElement(o);
+  }
+
+  public void visitElement3(@NotNull Element3 o) {
+    visitPsiElement(o);
+  }
+
+  public void visitPsiElement(@NotNull PsiElement o) {
+    visitElement(o);
+  }
+
+}

--- a/testData/generator/MixedAST.bnf
+++ b/testData/generator/MixedAST.bnf
@@ -1,0 +1,32 @@
+{
+  generatePsi=true
+  classHeader="//header.txt"
+  psiPackage="test.psi"
+  psiImplPackage="test.psi.impl"
+  psiTreeUtilClass="test.psi.MyPsiTreeUtil"
+  parserClass="test.FooParser"
+  elementTypeFactory="test.FooParserDefinition.createType"
+  tokenTypeFactory="test.FooParserDefinition.createTokenType"
+  elementTypeHolderClass="test.FooTypes"
+  parserUtilClass="org.intellij.grammar.parser.GeneratedParserUtilBase"
+  expressionUtilClass="test.FooUtil"
+  generateTokenAccessors=true
+  mixedAST = true
+
+  extends='test.CompositePsiElementImpl'
+
+  tokens = [
+    AA = 'aa'
+    BB = 'bb'
+  ]
+}
+root ::= element1 | element2 | element3
+element1 ::= AA
+element2 ::= BB {
+  mixedAST = false
+  extends='test.AstDelegatedPsiElementImpl'
+}
+element3 ::= BB {
+  stubClass="test.stub.Element3Stub"
+  extends='test.StubBasedPsiElementImpl<?>'
+}

--- a/testData/generator/MixedAST.expected.java
+++ b/testData/generator/MixedAST.expected.java
@@ -1,0 +1,87 @@
+// ---- FooParser.java -----------------
+//header.txt
+package test;
+
+import com.intellij.lang.PsiBuilder;
+import com.intellij.lang.PsiBuilder.Marker;
+import static test.FooTypes.*;
+import static org.intellij.grammar.parser.GeneratedParserUtilBase.*;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.tree.TokenSet;
+import com.intellij.lang.PsiParser;
+import com.intellij.lang.LightPsiParser;
+
+@SuppressWarnings({"SimplifiableIfStatement", "UnusedAssignment"})
+public class FooParser implements PsiParser, LightPsiParser {
+
+  public ASTNode parse(IElementType root_, PsiBuilder builder_) {
+    parseLight(root_, builder_);
+    return builder_.getTreeBuilt();
+  }
+
+  public void parseLight(IElementType root_, PsiBuilder builder_) {
+    boolean result_;
+    builder_ = adapt_builder_(root_, builder_, this, null);
+    Marker marker_ = enter_section_(builder_, 0, _COLLAPSE_, null);
+    result_ = parse_root_(root_, builder_);
+    exit_section_(builder_, 0, marker_, root_, result_, true, TRUE_CONDITION);
+  }
+
+  protected boolean parse_root_(IElementType root_, PsiBuilder builder_) {
+    return parse_root_(root_, builder_, 0);
+  }
+
+  static boolean parse_root_(IElementType root_, PsiBuilder builder_, int level_) {
+    return root(builder_, level_ + 1);
+  }
+
+  /* ********************************************************** */
+  // AA
+  public static boolean element1(PsiBuilder builder_, int level_) {
+    if (!recursion_guard_(builder_, level_, "element1")) return false;
+    if (!nextTokenIs(builder_, AA)) return false;
+    boolean result_;
+    Marker marker_ = enter_section_(builder_);
+    result_ = consumeToken(builder_, AA);
+    exit_section_(builder_, marker_, ELEMENT_1, result_);
+    return result_;
+  }
+
+  /* ********************************************************** */
+  // BB
+  public static boolean element2(PsiBuilder builder_, int level_) {
+    if (!recursion_guard_(builder_, level_, "element2")) return false;
+    if (!nextTokenIs(builder_, BB)) return false;
+    boolean result_;
+    Marker marker_ = enter_section_(builder_);
+    result_ = consumeToken(builder_, BB);
+    exit_section_(builder_, marker_, ELEMENT_2, result_);
+    return result_;
+  }
+
+  /* ********************************************************** */
+  // BB
+  public static boolean element3(PsiBuilder builder_, int level_) {
+    if (!recursion_guard_(builder_, level_, "element3")) return false;
+    if (!nextTokenIs(builder_, BB)) return false;
+    boolean result_;
+    Marker marker_ = enter_section_(builder_);
+    result_ = consumeToken(builder_, BB);
+    exit_section_(builder_, marker_, ELEMENT_3, result_);
+    return result_;
+  }
+
+  /* ********************************************************** */
+  // element1 | element2 | element3
+  static boolean root(PsiBuilder builder_, int level_) {
+    if (!recursion_guard_(builder_, level_, "root")) return false;
+    if (!nextTokenIs(builder_, "", AA, BB)) return false;
+    boolean result_;
+    result_ = element1(builder_, level_ + 1);
+    if (!result_) result_ = element2(builder_, level_ + 1);
+    if (!result_) result_ = element3(builder_, level_ + 1);
+    return result_;
+  }
+
+}

--- a/tests/org/intellij/grammar/BnfGeneratorTest.java
+++ b/tests/org/intellij/grammar/BnfGeneratorTest.java
@@ -36,6 +36,7 @@ public class BnfGeneratorTest extends BnfGeneratorTestCase {
   public void testTokenChoice() throws Exception { doGenTest(true); }
   public void testTokenChoiceNoSets() throws Exception { doGenTest(true); }
   public void testStub() throws Exception { doGenTest(true); }
+  public void testMixedAST() throws Exception { doGenTest(true); }
   public void testUtilMethods() throws Exception { doGenTest(true); }
   public void testBindersAndHooks() throws Exception { doGenTest(false); }
   public void testAutoRecovery() throws Exception { doGenTest(true); }


### PR DESCRIPTION
We are used to two different kinds of PSI implementations:
1. `ASTDelegatePsiElement`
```
+-----+         +-----+
| PSI | ------> | AST |
+-----+         +-----+
```
2. `StubBasedPsiElementBase`

```
+-----+         +-----+
| PSI | ------> | AST |
+-----+ \ OR    +-----+
         \
          \     +------+
           \ -> | Stub |
                +------+
```
 
But really there is a third option - **mix** PSI and AST in a single class/object:
```
+---------+
| PSI/AST |
+---------+
```

This is useful when a PSI element does not have a stub. In this case, additional AST object is not allocated, so we win in memory consumption, and the tree traversing will be fasted, so we win in CPU as well.
A PSI element can be mixed if it implements both `ASTNode` and `PsiElement` interfaces. This is already done in the platform class `CompositePsiElement`.

When extending `CompositePsiElement`, a psi implementation slightly differs from one extending `ASTDelegatePsiElement`. In particular, token accessors use `findPsiChildByType` instead of `findChildByType` and different constructor signature is needed:
```
public Element1Impl(IElementType type) {
  super(type);
}
```

Grammar-Kit supports mixed AST at the moment, but currently it figures out whether a BNF rule uses mixedAST or not by reading `.class` file content of its `extends` attribute and comparing its chain of superclasses with `com.intellij.psi.impl.source.tree.CompositePsiElement` name ([1](https://github.com/JetBrains/Grammar-Kit/blob/962eb8c3e50a10b33d3df0e9db97744fe4c7aebc/src/org/intellij/grammar/generator/ParserGenerator.java#L282), [2](https://github.com/JetBrains/Grammar-Kit/blob/962eb8c3e50a10b33d3df0e9db97744fe4c7aebc/src/org/intellij/grammar/java/JavaHelper.java#L566)).

Such approach requires extracting all possible superclasses and mixins of PSI nodes to a separate gradle module in order to compile it prior to Grammar-Kit invocation, which is a quite complex setup.

In this PR I've simplified it by introducing `mixedAST` attribute. If it is set to `true` (and the rule does not have a stub), Grammar-Kit will use `mixedAST` style for generated PSI impls without trying to read any `.class` files content in runtime