### PR TITLE
Add a generate option to use faster stub getters `getStubOrPsiChild`

### DIFF
--- a/resources/messages/attributeDescriptions/generate.html
+++ b/resources/messages/attributeDescriptions/generate.html
@@ -85,6 +85,11 @@ A list of generator options. Supersedes global generateXXX attributes.
     <td>Parser: generate FIRST-based look-ahead optimization</td>
   </tr>
   <tr>
+    <td>fast-stub-child-accessors</td>
+    <td>yes, <b>no</b></td>
+    <td>PSI: generate more performant stubbed PSI accessors. Requires exact-types="elements" or exact-types="all"</td>
+  </tr>
+  <tr>
     <td>java</td>
     <td>6, 8, <b>11</b>, etc.</td>
     <td>Generator: generate lambda-s or other language constructs supported in selected version</td>

--- a/src/org/intellij/grammar/generator/GenOptions.java
+++ b/src/org/intellij/grammar/generator/GenOptions.java
@@ -22,7 +22,8 @@ public class GenOptions {
   public final boolean generateTokenTypes;
   public final boolean generateTokenSets;
   public final boolean generateElementTypes;
-  public final String generateExactTypes;
+  public final boolean generateExactElements;
+  public final boolean generateExactTokens;
   public final boolean generateExtendedPin;
   public final boolean generatePsi;
   public final boolean generatePsiFactory;
@@ -30,6 +31,7 @@ public class GenOptions {
   public final boolean generateVisitor;
   public final String visitorValue;
   public final boolean generateFQN;
+  public final boolean generateFastStubChildAccessors;
   public final Case generateTokenCase;
   public final Case generateElementCase;
   public final boolean generateTokenAccessors;
@@ -45,7 +47,9 @@ public class GenOptions {
     generateTokenTypes = getGenerateOption(myFile, KnownAttribute.GENERATE_TOKENS, genOptions, "tokens");
     generateTokenSets = generateTokenTypes && "yes".equals(genOptions.get("token-sets"));
     generateElementTypes = !"no".equals(genOptions.get("elements"));
-    generateExactTypes = StringUtil.notNullize(genOptions.get("exact-types"));
+    String generateExactTypes = StringUtil.notNullize(genOptions.get("exact-types"));
+    generateExactElements = "all".equals(generateExactTypes) || generateExactTypes.contains("elements");
+    generateExactTokens = "all".equals(generateExactTypes) || generateExactTypes.contains("tokens");
     generateFirstCheck = getGenerateOption(myFile, KnownAttribute.GENERATE_FIRST_CHECK, genOptions, "first-check", "firstCheck");
     generateExtendedPin = getGenerateOption(myFile, KnownAttribute.EXTENDED_PIN, genOptions, "extended-pin", "extendedPin");
     generateTokenAccessors = getGenerateOption(myFile, KnownAttribute.GENERATE_TOKEN_ACCESSORS, genOptions, "token-accessors", "tokenAccessors");
@@ -53,6 +57,7 @@ public class GenOptions {
     generateVisitor = !"no".equals(genOptions.get("visitor"));
     visitorValue = "void".equals(genOptions.get("visitor-value")) ? null : StringUtil.nullize(genOptions.get("visitor-value"));
     generateFQN = "yes".equals(genOptions.get("fqn"));
+    generateFastStubChildAccessors = generateExactElements && "yes".equals(genOptions.get("fast-stub-child-accessors"));
 
     generateTokenCase = ParserGeneratorUtil.enumFromString(genOptions.get("token-case"), Case.UPPER);
     generateElementCase = ParserGeneratorUtil.enumFromString(genOptions.get("element-case"), Case.UPPER);

--- a/testData/generator/Stub.PSI.expected.java
+++ b/testData/generator/Stub.PSI.expected.java
@@ -15,6 +15,7 @@ public interface FooTypes {
   IElementType ELEMENT_3 = FooParserDefinition.createType("ELEMENT_3");
   IElementType ELEMENT_4 = FooParserDefinition.createType("ELEMENT_4");
   IElementType ELEMENT_5 = FooParserDefinition.createType("ELEMENT_5");
+  IElementType ELEMENT_6 = FooParserDefinition.createType("ELEMENT_6");
   IElementType INTERFACE_TYPE = FooParserDefinition.createType("INTERFACE_TYPE");
   IElementType STRUCT_TYPE = FooParserDefinition.createType("STRUCT_TYPE");
   IElementType TYPE = FooParserDefinition.createType("TYPE");
@@ -37,6 +38,9 @@ public interface FooTypes {
       }
       else if (type == ELEMENT_5) {
         return new Element5Impl(node);
+      }
+      else if (type == ELEMENT_6) {
+        return new Element6Impl(node);
       }
       else if (type == INTERFACE_TYPE) {
         return new InterfaceTypeImpl(node);
@@ -121,6 +125,20 @@ import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 
 public interface Element5 extends PsiElement {
+
+}
+// ---- Element6.java -----------------
+//header.txt
+package test.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+
+public interface Element6 extends PsiElement {
+
+  @NotNull
+  Type getType();
 
 }
 // ---- InterfaceType.java -----------------
@@ -324,7 +342,7 @@ public class Element3Impl extends StubBasedPsiElementBase<Element3Stub> implemen
   @Override
   @NotNull
   public Element4 getElement4() {
-    return notNullChild(MyPsiTreeUtil.getStubChildOfType(this, Element4.class));
+    return notNullChild(getStubOrPsiChild(ELEMENT_4));
   }
 
 }
@@ -372,7 +390,7 @@ public class Element4Impl extends StubBasedPsiElementBase<Element4Stub> implemen
   @Override
   @Nullable
   public Element2 getElement2() {
-    return MyPsiTreeUtil.getStubChildOfType(this, Element2.class);
+    return getStubOrPsiChild(ELEMENT_2);
   }
 
 }
@@ -404,6 +422,43 @@ public class Element5Impl extends ASTWrapperPsiElement implements Element5 {
   public void accept(@NotNull PsiElementVisitor visitor) {
     if (visitor instanceof Visitor) accept((Visitor)visitor);
     else super.accept(visitor);
+  }
+
+}
+// ---- Element6Impl.java -----------------
+//header.txt
+package test.psi.impl;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import test.psi.MyPsiTreeUtil;
+import static test.FooTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import test.psi.*;
+
+public class Element6Impl extends ASTWrapperPsiElement implements Element6 {
+
+  public Element6Impl(@NotNull ASTNode node) {
+    super(node);
+  }
+
+  public void accept(@NotNull Visitor visitor) {
+    visitor.visitElement6(this);
+  }
+
+  @Override
+  public void accept(@NotNull PsiElementVisitor visitor) {
+    if (visitor instanceof Visitor) accept((Visitor)visitor);
+    else super.accept(visitor);
+  }
+
+  @Override
+  @NotNull
+  public Type getType() {
+    return notNullChild(MyPsiTreeUtil.getChildOfType(this, Type.class));
   }
 
 }
@@ -634,6 +689,10 @@ public class Visitor extends PsiElementVisitor {
   }
 
   public void visitElement5(@NotNull Element5 o) {
+    visitPsiElement(o);
+  }
+
+  public void visitElement6(@NotNull Element6 o) {
     visitPsiElement(o);
   }
 

--- a/testData/generator/Stub.bnf
+++ b/testData/generator/Stub.bnf
@@ -11,18 +11,24 @@
   parserUtilClass="org.intellij.grammar.parser.GeneratedParserUtilBase"
   expressionUtilClass="test.FooUtil"
 
+  generate = [
+    exact-types = "elements"
+    fast-stub-child-accessors = "yes"
+  ]
+
   extends("element1|type")="org.intellij.grammar.test.StubTest.GenericBase<?>"
   extends("simple")="org.intellij.grammar.test.StubTest.SimpleBase"
   extends("missing")="test.stub.MissingBase"
 
   extends(".*type")=type
 }
-root ::= element1 | element2 | element3 | element4 | element5 | type
+root ::= element1 | element2 | element3 | element4 | element5 | element6
 element1 ::= 'aa' element5   { stubClass="test.stub.Element1Stub" }
 element2 ::= 'bb' element4*  { stubClass="test.stub.Element2Stub" }
 element3 ::= 'bb' element4   { stubClass="test.stub.Element3Stub" }
 element4 ::= 'bb' | element2 { stubClass="test.stub.Element4Stub" }
 element5 ::= 'cc'
+element6 ::= 'dd' type
 
 type ::= interface_type | struct_type {stubClass="test.stub.TypeStub"}
 struct_type ::= 'struct'

--- a/testData/generator/Stub.expected.java
+++ b/testData/generator/Stub.expected.java
@@ -111,6 +111,18 @@ public class FooParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
+  // 'dd' type
+  public static boolean element6(PsiBuilder builder_, int level_) {
+    if (!recursion_guard_(builder_, level_, "element6")) return false;
+    boolean result_;
+    Marker marker_ = enter_section_(builder_, level_, _NONE_, ELEMENT_6, "<element 6>");
+    result_ = consumeToken(builder_, "dd");
+    result_ = result_ && type(builder_, level_ + 1);
+    exit_section_(builder_, level_, marker_, result_, false, null);
+    return result_;
+  }
+
+  /* ********************************************************** */
   // 'interface'
   public static boolean interface_type(PsiBuilder builder_, int level_) {
     if (!recursion_guard_(builder_, level_, "interface_type")) return false;
@@ -122,7 +134,7 @@ public class FooParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // element1 | element2 | element3 | element4 | element5 | type
+  // element1 | element2 | element3 | element4 | element5 | element6
   static boolean root(PsiBuilder builder_, int level_) {
     if (!recursion_guard_(builder_, level_, "root")) return false;
     boolean result_;
@@ -131,7 +143,7 @@ public class FooParser implements PsiParser, LightPsiParser {
     if (!result_) result_ = element3(builder_, level_ + 1);
     if (!result_) result_ = element4(builder_, level_ + 1);
     if (!result_) result_ = element5(builder_, level_ + 1);
-    if (!result_) result_ = type(builder_, level_ + 1);
+    if (!result_) result_ = element6(builder_, level_ + 1);
     return result_;
   }
 


### PR DESCRIPTION
`getStubOrPsiChild(IStubElementType)` works faster than usual `MyPsiTreeUtil.getStubChildOfType`. It can be used if the child rule does not have rules extending it and if there are exact types for stub element types.

```
generate = [
  exact-types = "elements"
  fast-stub-child-accessors = "yes"
]
```

With such configuration, Grammar-Kit will generate such implementations for PSI accessors for stubbed elements:

```
public Element4 getElement4() {
  return notNullChild(getStubOrPsiChild(ELEMENT_4));
}
```