### PR TITLE
fix(jflex): Incorrect `java_type` Rule In JFlex Grammar

### DIFF
--- a/grammars/JFlex.bnf
+++ b/grammars/JFlex.bnf
@@ -149,9 +149,12 @@ user_code_section ::= [] java_code {pin=1}
 user_value ::= <<anything2 !new_line>>
 java_code ::= raw? { methods=[getReferences] }
 
-java_type ::= id ( safe_dot id ) * {pin(".*")=1 methods=[getReferences]}
+java_type ::= (id safe_dot ) * java_class_name {pin(".*")=1 methods=[getReferences]}
+
+private java_class_name ::= id ['<' java_class_name_list '>']
 private safe_dot ::= '.' !'*'
 private java_type_list ::= [java_type (',' java_type) *] {pin(".*")=1 recoverWhile=declaration_recover}
+private java_class_name_list ::= [java_class_name (',' java_class_name) *] {pin(".*")=1 recoverWhile=declaration_recover}
 
 // ======================================================
 declarations_section ::= [] declaration (!(<<eof>> | '%%') declaration) * {pin(".*")=1}


### PR DESCRIPTION
- The previous rule for `java_type` was VERY simple, my assumption is that generics were left out due to forgetfulness as I myself always seem to forget to implement generics in my grammars. I have edited this rule to instead reflect `(id safe_dot ) * java_class_name`

This commit fixes issue #333 