### PR TITLE
Update elm and haxe plugins to the most alive versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Open-source plugins built with Grammar-Kit:
   [intellij-erlang](https://github.com/ignatov/intellij-erlang),
   [go-lang-idea-plugin](https://github.com/go-lang-plugin-org/go-lang-idea-plugin),
 * [intellij-haskforce](https://github.com/carymrobbins/intellij-haskforce), 
-  [elm-plugin](https://github.com/durkiewicz/elm-plugin),
+  [elm-plugin](https://github.com/intellij-elm/intellij-elm/tree/master),
   [intellij-elixir](https://github.com/KronicDeth/intellij-elixir),
   [Perl5-IDEA](https://github.com/Camelcade/Perl5-IDEA),
 * [Dart](https://github.com/JetBrains/intellij-plugins/tree/master/Dart), 
-  [intellij-haxe](https://github.com/JetBrains/intellij-haxe),
+  [intellij-haxe](https://github.com/HaxeFoundation/intellij-haxe),
   [Cypher](https://github.com/neueda/jetbrains-plugin-graph-database-support),
   [OGNL](https://github.com/JetBrains/intellij-plugins/tree/master/struts2)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Open-source plugins built with Grammar-Kit:
   [intellij-erlang](https://github.com/ignatov/intellij-erlang),
   [go-lang-idea-plugin](https://github.com/go-lang-plugin-org/go-lang-idea-plugin),
 * [intellij-haskforce](https://github.com/carymrobbins/intellij-haskforce), 
-  [elm-plugin](https://github.com/intellij-elm/intellij-elm/tree/master),
+  [intellij-elm](https://github.com/intellij-elm/intellij-elm),
   [intellij-elixir](https://github.com/KronicDeth/intellij-elixir),
   [Perl5-IDEA](https://github.com/Camelcade/Perl5-IDEA),
 * [Dart](https://github.com/JetBrains/intellij-plugins/tree/master/Dart), 


### PR DESCRIPTION
I don't want to be mean to people who built previously mentioned versions, but for these two languages the repos mentioned are dead for a long time. (I also checked the others, but for them I either don't know better alternatives or they are alive 😺 )

For Haxe the new repo seems to be an original repo that was forked a long time ago, which has the same license and still uses grammarkit.
For elm the new one also uses grammarkit but most probably unrelated to the old one. 
