### PR TITLE
Implicit token highlighting

### DIFF
--- a/src/org/intellij/grammar/editor/BnfAnnotator.java
+++ b/src/org/intellij/grammar/editor/BnfAnnotator.java
@@ -100,7 +100,7 @@ final class BnfAnnotator implements Annotator, DumbAware {
         if (RuleGraphHelper.getTokenNameToTextMap((BnfFile)refOrToken.getContainingFile()).containsKey(text)) {
           annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)
             .range(refOrToken)
-            .textAttributes(BnfSyntaxHighlighter.TOKEN)
+            .textAttributes(BnfSyntaxHighlighter.EXPLICIT_TOKEN)
             .create();
         } else {
           annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)

--- a/src/org/intellij/grammar/editor/BnfAnnotator.java
+++ b/src/org/intellij/grammar/editor/BnfAnnotator.java
@@ -58,7 +58,7 @@ final class BnfAnnotator implements Annotator, DumbAware {
           .create();
       }
     }
-    else if (psiElement instanceof BnfReferenceOrToken) {
+    else if (psiElement instanceof BnfReferenceOrToken refOrToken) {
       if (parent instanceof BnfAttr) {
         String text = psiElement.getText();
         if ("true".equals(text) || "false".equals(text)) {
@@ -96,10 +96,18 @@ final class BnfAnnotator implements Annotator, DumbAware {
         }
       }
       else if (resolve == null) {
-        annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)
-          .range(psiElement)
-          .textAttributes(BnfSyntaxHighlighter.TOKEN)
-          .create();
+        var text = refOrToken.getId().getText();
+        if (RuleGraphHelper.getTokenNameToTextMap((BnfFile)psiElement.getContainingFile()).containsKey(text)) {
+          annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+            .range(psiElement)
+            .textAttributes(BnfSyntaxHighlighter.TOKEN)
+            .create();
+        } else {
+          annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+            .range(psiElement)
+            .textAttributes(BnfSyntaxHighlighter.IMPLICIT_TOKEN)
+            .create();
+        }
       }
     }
     else if (psiElement instanceof BnfStringLiteralExpression) {

--- a/src/org/intellij/grammar/editor/BnfAnnotator.java
+++ b/src/org/intellij/grammar/editor/BnfAnnotator.java
@@ -32,10 +32,10 @@ final class BnfAnnotator implements Annotator, DumbAware {
   @Override
   public void annotate(@NotNull PsiElement psiElement, @NotNull AnnotationHolder annotationHolder) {
     PsiElement parent = psiElement.getParent();
-    if (parent instanceof BnfRule && ((BnfRule)parent).getId() == psiElement) {
-      addRuleHighlighting((BnfRule)parent, psiElement, annotationHolder);
+    if (parent instanceof BnfRule rule && rule.getId() == psiElement) {
+      addRuleHighlighting(rule, psiElement, annotationHolder);
     }
-    else if (parent instanceof BnfAttr && ((BnfAttr)parent).getId() == psiElement) {
+    else if (parent instanceof BnfAttr attr && attr.getId() == psiElement) {
       annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)
         .range(psiElement)
         .textAttributes(BnfSyntaxHighlighter.ATTRIBUTE)
@@ -47,9 +47,9 @@ final class BnfAnnotator implements Annotator, DumbAware {
         .textAttributes(BnfSyntaxHighlighter.KEYWORD)
         .create();
     }
-    else if (parent instanceof BnfListEntry && ((BnfListEntry)parent).getId() == psiElement) {
-      boolean hasValue = ((BnfListEntry)parent).getLiteralExpression() != null;
-      BnfAttr attr = PsiTreeUtil.getParentOfType(parent, BnfAttr.class);
+    else if (parent instanceof BnfListEntry listEntry && listEntry.getId() == psiElement) {
+      boolean hasValue = listEntry.getLiteralExpression() != null;
+      BnfAttr attr = PsiTreeUtil.getParentOfType(listEntry, BnfAttr.class);
       KnownAttribute<?> attribute = attr != null ? KnownAttribute.getCompatibleAttribute(attr.getName()) : null;
       if (attribute == KnownAttribute.METHODS && !hasValue) {
         annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)
@@ -60,29 +60,29 @@ final class BnfAnnotator implements Annotator, DumbAware {
     }
     else if (psiElement instanceof BnfReferenceOrToken refOrToken) {
       if (parent instanceof BnfAttr) {
-        String text = psiElement.getText();
+        String text = refOrToken.getText();
         if ("true".equals(text) || "false".equals(text)) {
           annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)
-            .range(psiElement)
+            .range(refOrToken)
             .textAttributes(BnfSyntaxHighlighter.KEYWORD)
             .create();
           return;
         }
       }
-      PsiReference reference = psiElement.getReference();
+      PsiReference reference = refOrToken.getReference();
       Object resolve = reference == null ? null : reference.resolve();
-      if (resolve instanceof BnfRule) {
-        addRuleHighlighting((BnfRule)resolve, psiElement, annotationHolder);
+      if (resolve instanceof BnfRule rule) {
+        addRuleHighlighting(rule, refOrToken, annotationHolder);
       }
       else if (resolve instanceof BnfAttr) {
         annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)
-          .range(psiElement)
+          .range(refOrToken)
           .textAttributes(BnfSyntaxHighlighter.ATTRIBUTE)
           .create();
       }
-      else if (GrammarUtil.isExternalReference(psiElement)) {
-        if (resolve == null && parent instanceof BnfExternalExpression && ((BnfExternalExpression)parent).getArguments().isEmpty() &&
-            ParserGeneratorUtil.Rule.isMeta(ParserGeneratorUtil.Rule.of((BnfReferenceOrToken)psiElement))) {
+      else if (GrammarUtil.isExternalReference(refOrToken)) {
+        if (resolve == null && parent instanceof BnfExternalExpression extExpr && extExpr.getArguments().isEmpty() &&
+            ParserGeneratorUtil.Rule.isMeta(ParserGeneratorUtil.Rule.of(refOrToken))) {
           annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)
             .range(parent)
             .textAttributes(BnfSyntaxHighlighter.META_PARAM)
@@ -90,21 +90,21 @@ final class BnfAnnotator implements Annotator, DumbAware {
         }
         else {
           annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)
-            .range(psiElement)
+            .range(refOrToken)
             .textAttributes(BnfSyntaxHighlighter.EXTERNAL)
             .create();
         }
       }
       else if (resolve == null) {
         var text = refOrToken.getId().getText();
-        if (RuleGraphHelper.getTokenNameToTextMap((BnfFile)psiElement.getContainingFile()).containsKey(text)) {
+        if (RuleGraphHelper.getTokenNameToTextMap((BnfFile)refOrToken.getContainingFile()).containsKey(text)) {
           annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)
-            .range(psiElement)
+            .range(refOrToken)
             .textAttributes(BnfSyntaxHighlighter.TOKEN)
             .create();
         } else {
           annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)
-            .range(psiElement)
+            .range(refOrToken)
             .textAttributes(BnfSyntaxHighlighter.IMPLICIT_TOKEN)
             .create();
         }

--- a/src/org/intellij/grammar/editor/BnfColorSettingsPage.java
+++ b/src/org/intellij/grammar/editor/BnfColorSettingsPage.java
@@ -34,7 +34,7 @@ final class BnfColorSettingsPage implements ColorSettingsPage {
       new AttributesDescriptor("String", STRING),
       new AttributesDescriptor("Number", NUMBER),
       new AttributesDescriptor("Keyword", KEYWORD),
-      new AttributesDescriptor("Token", TOKEN),
+      new AttributesDescriptor("Explicit token", EXPLICIT_TOKEN),
       new AttributesDescriptor("Implicit token", IMPLICIT_TOKEN),
       new AttributesDescriptor("Rule", RULE),
       new AttributesDescriptor("Attribute", ATTRIBUTE),
@@ -114,7 +114,7 @@ final class BnfColorSettingsPage implements ColorSettingsPage {
     map.put("mr", META_RULE);
     map.put("a", ATTRIBUTE);
     map.put("pa", PATTERN);
-    map.put("t", TOKEN);
+    map.put("t", EXPLICIT_TOKEN);
     map.put("it", IMPLICIT_TOKEN);
     map.put("k", KEYWORD);
     map.put("e", EXTERNAL);

--- a/src/org/intellij/grammar/editor/BnfColorSettingsPage.java
+++ b/src/org/intellij/grammar/editor/BnfColorSettingsPage.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.options.colors.ColorDescriptor;
 import com.intellij.openapi.options.colors.ColorSettingsPage;
 import org.intellij.grammar.BnfIcons;
 import org.intellij.grammar.GrammarKitBundle;
+import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
@@ -77,7 +78,7 @@ final class BnfColorSettingsPage implements ColorSettingsPage {
   }
 
   @Override
-  public @NotNull String getDemoText() {
+  public @NotNull @Language("HTML") String getDemoText() {
     return """
       /*
        * Sample grammar

--- a/src/org/intellij/grammar/editor/BnfColorSettingsPage.java
+++ b/src/org/intellij/grammar/editor/BnfColorSettingsPage.java
@@ -34,6 +34,7 @@ final class BnfColorSettingsPage implements ColorSettingsPage {
       new AttributesDescriptor("Number", NUMBER),
       new AttributesDescriptor("Keyword", KEYWORD),
       new AttributesDescriptor("Token", TOKEN),
+      new AttributesDescriptor("Implicit token", IMPLICIT_TOKEN),
       new AttributesDescriptor("Rule", RULE),
       new AttributesDescriptor("Attribute", ATTRIBUTE),
       new AttributesDescriptor("Meta rule", META_RULE),
@@ -94,11 +95,11 @@ final class BnfColorSettingsPage implements ColorSettingsPage {
       }
       // Grammar rules
       <r>root</r> ::= <r>header</r> <r>content</r>
-      <r>header</r> ::= <t>DECLARE</t> <r>reference</r>
+      <r>header</r> ::= <it>DECLARE</it> <r>reference</r>
       <k>external</k> <r>reference</r> ::= <e>parseReference</e>
-      <k>private</k> <k>meta</k> <mr>comma_list</mr> ::= <pin><s>'('</s></pin> <mp><<p>></mp> (<pin><s>','</s></pin> <mp><<p>></mp>) * ')'
-      <k>private</k> <r>content</r> ::= <pin><t>AS</t></pin> <<<mr>comma_list</mr> <ru><r>element</r></ru>>> {<a>pin</a>=1}
-      <ru><r>element</r></ru> ::= <r>reference</r> [ {<pa>'+'</pa> | <pa>'-'</pa>} <r>reference</r> <t>ONLY</t>?] {<a>recoverWhile</a>=<r>element_recover</r>}
+      <k>private</k> <k>meta</k> <mr>comma_list</mr> ::= <pin><t>LEFT_PAREN</t></pin> <mp><<p>></mp> (<pin><s>','</s></pin> <mp><<p>></mp>) * <t>RIGHT_PAREN</t>
+      <k>private</k> <r>content</r> ::= <pin><it>AS</it></pin> <<<mr>comma_list</mr> <ru><r>element</r></ru>>> {<a>pin</a>=1}
+      <ru><r>element</r></ru> ::= <r>reference</r> [ {<pa>'+'</pa> | <pa>'-'</pa>} <r>reference</r> <it>ONLY</it>?] {<a>recoverWhile</a>=<r>element_recover</r>}
       <k>private</k> <r>element_recover</r> ::= !(',' | ')')
 
       """;
@@ -113,6 +114,7 @@ final class BnfColorSettingsPage implements ColorSettingsPage {
     map.put("a", ATTRIBUTE);
     map.put("pa", PATTERN);
     map.put("t", TOKEN);
+    map.put("it", IMPLICIT_TOKEN);
     map.put("k", KEYWORD);
     map.put("e", EXTERNAL);
     map.put("pin", PIN_MARKER);

--- a/src/org/intellij/grammar/editor/BnfSyntaxHighlighter.java
+++ b/src/org/intellij/grammar/editor/BnfSyntaxHighlighter.java
@@ -27,7 +27,7 @@ class BnfSyntaxHighlighter extends SyntaxHighlighterBase {
   public static final TextAttributesKey PATTERN = createTextAttributesKey("BNF_PATTERN", DefaultLanguageHighlighterColors.INSTANCE_FIELD);
   public static final TextAttributesKey NUMBER = createTextAttributesKey("BNF_NUMBER", DefaultLanguageHighlighterColors.NUMBER);
   public static final TextAttributesKey KEYWORD = createTextAttributesKey("BNF_KEYWORD", DefaultLanguageHighlighterColors.MARKUP_ATTRIBUTE);
-  public static final TextAttributesKey TOKEN = createTextAttributesKey("BNF_TOKEN", DefaultLanguageHighlighterColors.STRING);
+  public static final TextAttributesKey EXPLICIT_TOKEN = createTextAttributesKey("BNF_EXPLICIT_TOKEN", DefaultLanguageHighlighterColors.STRING);
   public static final TextAttributesKey IMPLICIT_TOKEN = createTextAttributesKey("BNF_IMPLICIT_TOKEN", DefaultLanguageHighlighterColors.STATIC_FIELD);
   public static final TextAttributesKey RULE = createTextAttributesKey("BNF_RULE", DefaultLanguageHighlighterColors.KEYWORD);
   public static final TextAttributesKey META_RULE = createTextAttributesKey("BNF_META_RULE", DefaultLanguageHighlighterColors.KEYWORD);

--- a/src/org/intellij/grammar/editor/BnfSyntaxHighlighter.java
+++ b/src/org/intellij/grammar/editor/BnfSyntaxHighlighter.java
@@ -28,6 +28,7 @@ class BnfSyntaxHighlighter extends SyntaxHighlighterBase {
   public static final TextAttributesKey NUMBER = createTextAttributesKey("BNF_NUMBER", DefaultLanguageHighlighterColors.NUMBER);
   public static final TextAttributesKey KEYWORD = createTextAttributesKey("BNF_KEYWORD", DefaultLanguageHighlighterColors.MARKUP_ATTRIBUTE);
   public static final TextAttributesKey TOKEN = createTextAttributesKey("BNF_TOKEN", DefaultLanguageHighlighterColors.STRING);
+  public static final TextAttributesKey IMPLICIT_TOKEN = createTextAttributesKey("BNF_IMPLICIT_TOKEN", DefaultLanguageHighlighterColors.STATIC_FIELD);
   public static final TextAttributesKey RULE = createTextAttributesKey("BNF_RULE", DefaultLanguageHighlighterColors.KEYWORD);
   public static final TextAttributesKey META_RULE = createTextAttributesKey("BNF_META_RULE", DefaultLanguageHighlighterColors.KEYWORD);
   public static final TextAttributesKey META_PARAM = createTextAttributesKey("BNF_META_RULE_PARAM");


### PR DESCRIPTION
### Motivation

Currently both implicit and explicit (terminology from [here](https://github.com/JetBrains/Grammar-Kit/blob/master/README.md#tokens)) share a common highlighting key: `BNF_TOKEN`, which makes it impossible to assign different highlighting styles to them and spot issues in the grammar, when e.g. because of a typo implicit token is used instead of the name of an explicit one.
E.g. this grammar
```bnf
{
  tokens = [
    OPEN_PARENTHESE = '('
    CLOSE_PARENTHESE = ')'
    ID = "regexp:\w+"
  ]
}

file ::= OPEN_PARENTHES ID+ CLOSE_PARENTHESE
```

Is highlighted like this
<img width="351" alt="изображение" src="https://github.com/user-attachments/assets/9c390ab0-0a88-4f14-8e6e-0585b5a3a389">

This PR makes it to be highlighted like this
<img width="351" alt="изображение" src="https://github.com/user-attachments/assets/6cc12e03-3050-40f0-891b-9374c7ea9038">
which lets developer notice that something's off, and overall distinguish explicit tokens, matched by name and implicitly defined tokens, the same way we already distinguish explicit tokens, matched by value and toekns, matched by text (called "patterns" in the code base)


### Additional changes
There are 2 sets of commits:
- those who introduce separate highlighting for implicit tokens, with minumal changes across the codebase
- those I considered to be nice to have (the have `fix:` prefix):
  - let IDEA highlight bnf example text on the color settings page as an HTML
  - use more of `instanceof` pattern matching syntax where I already started using it
  - rename `TOKEN` to `EXPLICIT_TOKEN` to make it symmetric with `IMPLICIT_TOKEN`

Please advice which of them are desired and which I must drop