### PR TITLE
Fix incorrect import with multiple TYPE_USE annotations

### DIFF
--- a/src/org/intellij/grammar/generator/NameShortener.java
+++ b/src/org/intellij/grammar/generator/NameShortener.java
@@ -109,6 +109,12 @@ public class NameShortener {
         if ("\"".equals(part) && offset > 0 && s.charAt(offset - 1) != '\\') quoted = !quoted;
         if (!quoted && "(".equals(part)) parenCount ++;
         if (!quoted && ")".equals(part)) parenCount --;
+        if (!quoted && "@".equals(part) && prefixStack != null && !prefixStack.isEmpty()) {
+          int[] top = prefixStack.peek();
+          if (parenCount == top[0]) {
+            top[3] = offset;
+          }
+        }
       }
       else if (!quoted && part.endsWith(".")) {
         if (prefixStack == null) prefixStack = new ArrayDeque<>();

--- a/tests/org/intellij/grammar/BnfUtilTest.java
+++ b/tests/org/intellij/grammar/BnfUtilTest.java
@@ -110,6 +110,36 @@ public class BnfUtilTest extends UsefulTestCase {
     assertEquals("@NotNull @Unmodifiable List<PsiElement>", shortener.shorten(longType));
   }
 
+  public void testNameShortener_multipleTypeUseAnnotationsWithArgs() {
+    String longType = "java.util.@org.jetbrains.annotations.NotNull(\"val\") @org.jetbrains.annotations.Unmodifiable List<java.lang.String>";
+    List<String> imports = new ArrayList<>();
+    NameShortener.addTypeToImports(longType, Collections.emptyList(), imports);
+    assertEquals(Arrays.asList("org.jetbrains.annotations.NotNull", "org.jetbrains.annotations.Unmodifiable", "java.util.List", "java.lang.String"), imports);
+    NameShortener shortener = new NameShortener("com", true);
+    shortener.addImports(imports, Collections.emptySet());
+    assertEquals("@NotNull(\"val\") @Unmodifiable List<String>", shortener.shorten(longType));
+  }
+
+  public void testNameShortener_threeTypeUseAnnotations() {
+    String longType = "java.util.@org.a.A @org.b.B @org.c.C List";
+    List<String> imports = new ArrayList<>();
+    NameShortener.addTypeToImports(longType, Collections.emptyList(), imports);
+    assertEquals(Arrays.asList("org.a.A", "org.b.B", "org.c.C", "java.util.List"), imports);
+    NameShortener shortener = new NameShortener("com", true);
+    shortener.addImports(imports, Collections.emptySet());
+    assertEquals("@A @B @C List", shortener.shorten(longType));
+  }
+
+  public void testNameShortener_multipleAnnotationsOnInnerGenericType() {
+    String longType = "java.util.Map<java.util.@org.a.A @org.b.B List<java.lang.String>, java.lang.Integer>";
+    List<String> imports = new ArrayList<>();
+    NameShortener.addTypeToImports(longType, Collections.emptyList(), imports);
+    assertEquals(Arrays.asList("java.util.Map", "org.a.A", "org.b.B", "java.util.List", "java.lang.String", "java.lang.Integer"), imports);
+    NameShortener shortener = new NameShortener("com", true);
+    shortener.addImports(imports, Collections.emptySet());
+    assertEquals("Map<@A @B List<String>, Integer>", shortener.shorten(longType));
+  }
+
   public void testNameShortener_escapedQuoteInAnnotation() {
     String longType = "java.util.@org.jetbrains.annotations.NotNull(\"escaped\\\"quote.pkg\") List<java.lang.Integer>";
     List<String> imports = new ArrayList<>();

--- a/tests/org/intellij/grammar/BnfUtilTest.java
+++ b/tests/org/intellij/grammar/BnfUtilTest.java
@@ -100,6 +100,16 @@ public class BnfUtilTest extends UsefulTestCase {
     assertEquals("@NotNull(\"some.text and.more\", arr = [@Nullable]) List<@Nullable Inner.Class<Integer>>", shortener.shorten(longType));
   }
 
+  public void testNameShortener_multipleTypeUseAnnotations() {
+    String longType = "java.util.@org.jetbrains.annotations.NotNull @org.jetbrains.annotations.Unmodifiable List<com.intellij.psi.PsiElement>";
+    List<String> imports = new ArrayList<>();
+    NameShortener.addTypeToImports(longType, Collections.emptyList(), imports);
+    assertEquals(Arrays.asList("org.jetbrains.annotations.NotNull", "org.jetbrains.annotations.Unmodifiable", "java.util.List", "com.intellij.psi.PsiElement"), imports);
+    NameShortener shortener = new NameShortener("com", true);
+    shortener.addImports(imports, Collections.emptySet());
+    assertEquals("@NotNull @Unmodifiable List<PsiElement>", shortener.shorten(longType));
+  }
+
   public void testNameShortener_escapedQuoteInAnnotation() {
     String longType = "java.util.@org.jetbrains.annotations.NotNull(\"escaped\\\"quote.pkg\") List<java.lang.Integer>";
     List<String> imports = new ArrayList<>();


### PR DESCRIPTION
## Summary

Fixes #437

- When a return type has two or more `TYPE_USE` annotations (e.g. `@NotNull @Unmodifiable List<PsiElement>`), `NameShortener.addTypeToImports()` generated an incorrect import like `java.util.org` instead of `java.util.List`
- The root cause was that the `@` position stored in the prefix stack was only set for the first annotation; subsequent `@` separators did not update it, causing the second annotation's FQN to be mistakenly matched as the class name
- Fix: update the tracked `@` position in the prefix stack each time a new `@` separator is encountered at the same parenthesis depth

## Test plan

- [x] Added `testNameShortener_multipleTypeUseAnnotations` covering import extraction and name shortening with two TYPE_USE annotations
- [x] Existing `BnfUtilTest` tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)