### PR TITLE
Fix incorrect escaped-quote detection in NameShortener

### DIFF
--- a/src/org/intellij/grammar/generator/NameShortener.java
+++ b/src/org/intellij/grammar/generator/NameShortener.java
@@ -59,7 +59,7 @@ public class NameShortener {
       String pkg;
       if (TYPE_TEXT_SEPARATORS.contains(part) ||
           "?".equals(part) || "extends".equals(part) || "super".equals(part)) {
-        if ("\"".equals(part) && offset > 0 && s.indexOf(offset - 1) != '\\') quoted = !quoted;
+        if ("\"".equals(part) && offset > 0 && s.charAt(offset - 1) != '\\') quoted = !quoted;
         sb.append(part);
         if (",".equals(part) && offset < len && !Character.isWhitespace(s.charAt(offset + 1))) {
           sb.append(" "); // Map<K,V> psi types skip space after comma
@@ -106,7 +106,7 @@ public class NameShortener {
     for (String part : StringUtil.tokenize(new StringTokenizer(StringUtil.trimEnd(s, "..."), TYPE_TEXT_SEPARATORS, true))) {
       if (TYPE_TEXT_SEPARATORS.contains(part) ||
           "?".equals(part) || "extends".equals(part) || "super".equals(part)) {
-        if ("\"".equals(part) && offset > 0 && s.indexOf(offset - 1) != '\\') quoted = !quoted;
+        if ("\"".equals(part) && offset > 0 && s.charAt(offset - 1) != '\\') quoted = !quoted;
         if (!quoted && "(".equals(part)) parenCount ++;
         if (!quoted && ")".equals(part)) parenCount --;
       }

--- a/tests/org/intellij/grammar/BnfUtilTest.java
+++ b/tests/org/intellij/grammar/BnfUtilTest.java
@@ -100,6 +100,16 @@ public class BnfUtilTest extends UsefulTestCase {
     assertEquals("@NotNull(\"some.text and.more\", arr = [@Nullable]) List<@Nullable Inner.Class<Integer>>", shortener.shorten(longType));
   }
 
+  public void testNameShortener_escapedQuoteInAnnotation() {
+    String longType = "java.util.@org.jetbrains.annotations.NotNull(\"escaped\\\"quote.pkg\") List<java.lang.Integer>";
+    List<String> imports = new ArrayList<>();
+    NameShortener.addTypeToImports(longType, Collections.emptyList(), imports);
+    assertEquals(Arrays.asList("org.jetbrains.annotations.NotNull", "java.util.List", "java.lang.Integer"), imports);
+    NameShortener shortener = new NameShortener("com", true);
+    shortener.addImports(imports, Collections.emptySet());
+    assertEquals("@NotNull(\"escaped\\\"quote.pkg\") List<Integer>", shortener.shorten(longType));
+  }
+
   public void testNameShortener3() {
     String longType = "java.util.@org.jetbrains.annotations.NotNull(\"some.text and.more\",arr = [@Nullable]) List<sample.@Nullable Inner.Class<java.lang.Integer>>";
     NameShortener shortener = new NameShortener("sample", false);


### PR DESCRIPTION
## Summary

- Fix `s.indexOf(offset - 1)` → `s.charAt(offset - 1)` in `NameShortener.shorten()` and `addTypeToImports()`
- `String.indexOf(int ch)` searches for the character with codepoint `offset - 1` anywhere in the string; the intent was `String.charAt(int)` to check whether the preceding character is a backslash for escaped-quote detection
- Add regression test with escaped quotes inside annotation argument strings

## Test plan

- [x] New `testNameShortener_escapedQuoteInAnnotation` passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)