### PR TITLE
  Add explicit output-path attributes for parser, PSI, element types

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,3 +265,62 @@ Element type constants are generated as `val` declarations in a Kotlin `object` 
 
 [jb:slack]: https://plugins.jetbrains.com/slack
 [jb:x]: https://x.com/JBPlatform
+                                              
+
+Headless CLI
+------------
+
+Grammar-Kit ships a headless entry point at `org.intellij.grammar.Main` for build scripts and CI:
+
+```
+java -cp <grammar-kit-and-deps> org.intellij.grammar.Main <grammar-file> [options]
+```
+
+The grammar file can be a path or a glob pattern (e.g. `grammars/*.bnf`). Output directories
+can be set per-attribute either inside the grammar header or via CLI flags — flags mirror the
+attribute names:
+
+| Flag                                             | Grammar attribute                       |
+|--------------------------------------------------|-----------------------------------------|
+| `--parser-output <path>`                         | `parserOutputPath`                      |
+| `--psi-output <path>`                            | `psiOutputPath`                         |
+| `--element-type-holder-output <path>`            | `elementTypeHolderOutputPath`           |
+| `--syntax-element-type-holder-output <path>`     | `syntaxElementTypeHolderOutputPath`     |
+| `--element-type-converter-factory-output <path>` | `elementTypeConverterFactoryOutputPath` |
+
+**Setting paths in the grammar.** All five path attributes can also be declared in the grammar
+header. Values are resolved relative to the BNF file's parent directory; an empty string is
+treated as unset. The IDE's *Generate Parser* action and the headless CLI honor the same
+attributes, so a grammar that pins its layout works the same way in both:
+
+```
+{
+  parserClass="com.example.MyParser"
+  parserOutputPath="../build/gen"          // where the parser file lands
+  psiOutputPath="../build/gen-psi"         // PSI separated from parser
+  elementTypeHolderOutputPath="../build/gen-types"
+
+  parserUtilClass="com.example.MyParserUtil"
+}
+```
+
+Per-attribute documentation is available via Ctrl-Q / Cmd-J on the attribute name in the IDE.
+
+**Per-path precedence.** Resolution is per attribute, not global: a CLI flag overrides only the
+attribute it names, leaving other grammar-declared paths intact. Unset output paths cascade from
+`parserOutputPath` (parser → psi → element-type holders/converter), so passing only
+`--parser-output` is enough for typical projects.
+
+**Conflict handling.** When the same attribute is set both on the CLI and in the grammar header
+with different values, the CLI value wins and a warning is printed to stderr:
+
+```
+warning: parserOutputPath: CLI value '/build/gen' overrides grammar value '/src/gen'
+```
+
+Pass `--strict-paths` to make such conflicts fatal (exit code 1) — useful for CI to catch drift
+between build scripts and grammar headers.
+
+**Legacy form.** The old positional invocation `Main <output-dir> <grammars or patterns>` is still
+accepted but emits a deprecation warning. It is equivalent to passing `--parser-output <output-dir>`
+in the new form. New scripts should use the flag form.

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Grammar-Kit ships a headless entry point at `org.intellij.grammar.Main` for buil
 java -cp <grammar-kit-and-deps> org.intellij.grammar.Main <grammar-file> [options]
 ```
 
-The grammar file can be a path or a glob pattern (e.g. `grammars/*.bnf`). Output directories
+The grammar file can be a path or a glob pattern (e.g. `grammars/*.bnf`). Output and input directories
 can be set per-attribute either inside the grammar header or via CLI flags — flags mirror the
 attribute names:
 
@@ -287,8 +287,10 @@ attribute names:
 | `--element-type-holder-output <path>`            | `elementTypeHolderOutputPath`           |
 | `--syntax-element-type-holder-output <path>`     | `syntaxElementTypeHolderOutputPath`     |
 | `--element-type-converter-factory-output <path>` | `elementTypeConverterFactoryOutputPath` |
+| `--input-path <path>`                            | `inputPath`                             |
+| `--psi-input <path>`                             | `psiInputPath`                          |
 
-**Setting paths in the grammar.** All five path attributes can also be declared in the grammar
+**Setting paths in the grammar.** All seven path attributes can also be declared in the grammar
 header. Values are resolved relative to the BNF file's parent directory; an empty string is
 treated as unset. The IDE's *Generate Parser* action and the headless CLI honor the same
 attributes, so a grammar that pins its layout works the same way in both:
@@ -300,7 +302,10 @@ attributes, so a grammar that pins its layout works the same way in both:
   psiOutputPath="../build/gen-psi"         // PSI separated from parser
   elementTypeHolderOutputPath="../build/gen-types"
 
-  parserUtilClass="com.example.MyParserUtil"
+  inputPath="../java"                      // narrows IDE class lookup for FQN-valued
+                                           // input attributes (parserUtilClass, …)
+  psiInputPath="../psi-src"                // optional override for psiImplUtilClass,
+                                           // mixin, and implements
 }
 ```
 

--- a/base/resources/messages/GrammarKitBundle.properties
+++ b/base/resources/messages/GrammarKitBundle.properties
@@ -40,3 +40,6 @@ inspection.message.pattern.does.not.match.any.rule=Pattern does not match any ru
 diagram.category.properties=Properties
 diagram.action.name=Diagram
 diagram.presentable.name=Grammar-Kit BNF
+
+inlay.bnf.path.attribute.name=Resolved path for path attributes
+inlay.bnf.path.attribute.description=Shows the absolute filesystem location an *InputPath / *OutputPath attribute resolves to (relative to the BNF file's parent directory).

--- a/bnf-language/resources/messages/attributeDescriptions/elementTypeConverterFactoryOutputPath.html
+++ b/bnf-language/resources/messages/attributeDescriptions/elementTypeConverterFactoryOutputPath.html
@@ -1,0 +1,24 @@
+<html>
+<body>
+A path to generate the syntax-API element-type converter-factory class in, resolved <b>relative to
+the BNF file's parent directory</b>. Applies only when the syntax-API parser is enabled
+(<code>generate=[parser-api="syntax"]</code>); when unset, falls back to the PSI directory.
+
+<h2>Examples:</h2>
+<pre><code>
+  {
+    generate=[parser-api="syntax"]
+    elementTypeConverterFactoryClass="com.example.MyConverterFactory"
+    //Given that BNF file is located at "path/to/project/grammar.bnf"
+    //Resulting factory file would be placed in "path/to/project/generated/converter/com/example/MyConverterFactory.java"
+    elementTypeConverterFactoryOutputPath="generated/converter"
+  }
+</code></pre>
+
+<p><b>CLI override:</b> the headless generator accepts
+<code>--element-type-converter-factory-output &lt;path&gt;</code>. When both this attribute and the
+CLI flag specify different paths, the CLI value wins and a warning is printed. Pass
+<code>--strict-paths</code> to make such conflicts fatal.</p>
+
+</body>
+</html>

--- a/bnf-language/resources/messages/attributeDescriptions/elementTypeHolderOutputPath.html
+++ b/bnf-language/resources/messages/attributeDescriptions/elementTypeHolderOutputPath.html
@@ -1,0 +1,23 @@
+<html>
+<body>
+A path to generate the IElement-type holder class in, resolved <b>relative to the BNF file's parent
+directory</b>. When unset, the holder is written next to the parser (in pure-Java mode) or next to
+the PSI files (in syntax-API/Kotlin mode), preserving previous behavior.
+
+<h2>Examples:</h2>
+<pre><code>
+  {
+    elementTypeHolderClass="com.example.MyTypes"
+    //Given that BNF file is located at "path/to/project/grammar.bnf"
+    //Resulting holder file would be placed in "path/to/project/generated/types/com/example/MyTypes.java"
+    elementTypeHolderOutputPath="generated/types"
+  }
+</code></pre>
+
+<p><b>CLI override:</b> the headless generator accepts
+<code>--element-type-holder-output &lt;path&gt;</code>. When both this attribute and the CLI flag
+specify different paths, the CLI value wins and a warning is printed. Pass
+<code>--strict-paths</code> to make such conflicts fatal.</p>
+
+</body>
+</html>

--- a/bnf-language/resources/messages/attributeDescriptions/inputPath.html
+++ b/bnf-language/resources/messages/attributeDescriptions/inputPath.html
@@ -1,0 +1,26 @@
+<html>
+<body>
+A default source root to look up FQN-valued input attributes (such as <code>parserUtilClass</code>,
+<code>psiImplUtilClass</code>, <code>mixin</code>, <code>extends</code>, <code>implements</code>),
+resolved <b>relative to the BNF file's parent directory</b>. When set, narrows the IDE's
+<code>PsiHelper</code> class lookups from the project-wide scope to the named directory. Has no
+effect on headless / classloader-based resolution (<code>AsmHelper</code>, <code>ReflectionHelper</code>).
+
+<p>For PSI-side overrides (<code>psiImplUtilClass</code>, per-rule <code>mixin</code> and
+<code>implements</code>) see <code>psiInputPath</code>.</p>
+
+<h2>Examples:</h2>
+<pre><code>
+  {
+    //Given that BNF file is located at "path/to/project/someModule/src/main/grammars/grammar.bnf"
+    //All FQN inputs are resolved within "path/to/project/someModule/src/main/java"
+    inputPath="../java"
+  }
+</code></pre>
+
+<p><b>CLI override:</b> the headless generator accepts <code>--input-path &lt;path&gt;</code>.
+When both this attribute and the CLI flag specify different paths, the CLI value wins and a
+warning is printed. Pass <code>--strict-paths</code> to make such conflicts fatal.</p>
+
+</body>
+</html>

--- a/bnf-language/resources/messages/attributeDescriptions/parserOutputPath.html
+++ b/bnf-language/resources/messages/attributeDescriptions/parserOutputPath.html
@@ -1,0 +1,22 @@
+<html>
+<body>
+A path to generate the parser file(s) in, resolved <b>relative to the BNF file's parent directory</b>.
+When set, the parser class's package is no longer used to derive the output directory; the explicit
+value wins.
+
+<h2>Examples:</h2>
+<pre><code>
+  {
+    parserClass="com.example.MyParser"
+    //Given that BNF file is located at "path/to/project/grammar.bnf"
+    //Resulting parser file would be placed in "path/to/project/build/gen/com/example/MyParser.java"
+    parserOutputPath="build/gen"
+  }
+</code></pre>
+
+<p><b>CLI override:</b> the headless generator accepts <code>--parser-output &lt;path&gt;</code>.
+When both this attribute and the CLI flag specify different paths, the CLI value wins and a
+warning is printed. Pass <code>--strict-paths</code> to make such conflicts fatal.</p>
+
+</body>
+</html>

--- a/bnf-language/resources/messages/attributeDescriptions/psiInputPath.html
+++ b/bnf-language/resources/messages/attributeDescriptions/psiInputPath.html
@@ -1,0 +1,30 @@
+<html>
+<body>
+The source root that holds the user-authored PSI-side classes referenced by
+<code>psiImplUtilClass</code>, per-rule <code>mixin</code>, and per-rule <code>implements</code>,
+resolved <b>relative to the BNF file's parent directory</b>. When set, narrows the IDE's
+<code>PsiHelper.findClass</code> scope for those three attributes to the named directory. Falls
+back to the global <code>inputPath</code> default when unset, and finally to project-wide search.
+Has no effect on headless / classloader-based resolution (<code>AsmHelper</code>,
+<code>ReflectionHelper</code>).
+
+<p>One knob covers all three because <code>psiImplUtilClass</code>, <code>mixin</code> targets, and
+<code>implements</code> interfaces typically live together in the same source root.</p>
+
+<h2>Examples:</h2>
+<pre><code>
+  {
+    //BNF at "path/to/project/grammars/grammar.bnf" -> mixin / implements / psiImplUtilClass
+    //classes resolved against "path/to/project/grammars/../psi-src"
+    psiInputPath="../psi-src"
+    psiImplUtilClass="com.example.MyPsiImplUtil"
+  }
+  myRule ::= ... { mixin="com.example.MyRuleMixin" implements="com.example.MyMarker" }
+</code></pre>
+
+<p><b>CLI override:</b> the headless generator accepts <code>--psi-input &lt;path&gt;</code>.
+When both this attribute and the CLI flag specify different paths, the CLI value wins and a
+warning is printed. Pass <code>--strict-paths</code> to make such conflicts fatal.</p>
+
+</body>
+</html>

--- a/bnf-language/resources/messages/attributeDescriptions/psiOutputPath.html
+++ b/bnf-language/resources/messages/attributeDescriptions/psiOutputPath.html
@@ -1,16 +1,28 @@
 <html>
 <body>
-A path to generate PSI-files in, relative to the content root of the BNF file. Used for separating PSI logic from parsers. 
-It is required if a Syntax-API parser is intended to be KMP-compatible. (Kotlin-based generation only)
+A path to generate PSI interfaces, implementation classes, and the visitor in, resolved
+<b>relative to the BNF file's parent directory</b>. Used for separating PSI logic from the parser.
+Applies to both Java and Kotlin (syntax-API) generation; required when a Syntax-API parser is
+intended to be KMP-compatible. When unset, PSI files are written next to the parser.
 
 <h2>Examples:</h2>
 <pre><code>
   {
-    //Given that BNF file is located at "path/to/project/somModule/src/main/grammars/grammar.bnf"
-    //Resulting PSI files would be placed in "path/to/project/someOtherModule/output/gen"
+    //Given that BNF file is located at "path/to/project/someModule/src/main/grammars/grammar.bnf"
+    //Resulting PSI files would be placed in "path/to/project/someModule/src/main/grammars/../someOtherModule/output/generated/psi/..."
+    //(i.e. "path/to/project/someModule/src/main/someOtherModule/output/...")
     psiOutputPath="../someOtherModule/output"
   }
 </code></pre>
+
+<p>For finer-grained control over individual artifacts, see also
+<code>parserOutputPath</code>, <code>elementTypeHolderOutputPath</code>,
+<code>syntaxElementTypeHolderOutputPath</code>, and
+<code>elementTypeConverterFactoryOutputPath</code>.</p>
+
+<p><b>CLI override:</b> the headless generator accepts <code>--psi-output &lt;path&gt;</code>.
+When both this attribute and the CLI flag specify different paths, the CLI value wins and a
+warning is printed. Pass <code>--strict-paths</code> to make such conflicts fatal.</p>
 
 </body>
 </html>

--- a/bnf-language/resources/messages/attributeDescriptions/syntaxElementTypeHolderOutputPath.html
+++ b/bnf-language/resources/messages/attributeDescriptions/syntaxElementTypeHolderOutputPath.html
@@ -1,0 +1,24 @@
+<html>
+<body>
+A path to generate the Kotlin syntax-element-type holder in, resolved <b>relative to the BNF file's
+parent directory</b>. Applies only when the syntax-API parser is enabled
+(<code>generate=[parser-api="syntax"]</code>).
+
+<h2>Examples:</h2>
+<pre><code>
+  {
+    generate=[parser-api="syntax"]
+    syntaxElementTypeHolderClass="com.example.MySyntaxTypes"
+    //Given that BNF file is located at "path/to/project/grammar.bnf"
+    //Resulting holder file would be placed in "path/to/project/generated/syntax-types/com/example/MySyntaxTypes.kt"
+    syntaxElementTypeHolderOutputPath="generated/syntax-types"
+  }
+</code></pre>
+
+<p><b>CLI override:</b> the headless generator accepts
+<code>--syntax-element-type-holder-output &lt;path&gt;</code>. When both this attribute and the
+CLI flag specify different paths, the CLI value wins and a warning is printed. Pass
+<code>--strict-paths</code> to make such conflicts fatal.</p>
+
+</body>
+</html>

--- a/bnf-language/src/org/intellij/grammar/BnfPaths.java
+++ b/bnf-language/src/org/intellij/grammar/BnfPaths.java
@@ -16,6 +16,7 @@ import com.intellij.psi.util.CachedValueProvider;
 import com.intellij.psi.util.CachedValuesManager;
 import com.intellij.psi.util.PsiModificationTracker;
 import com.intellij.util.ArrayUtil;
+import com.intellij.util.containers.ContainerUtil;
 import org.intellij.grammar.config.Options;
 import org.intellij.grammar.psi.BnfFile;
 import org.jetbrains.annotations.NotNull;
@@ -34,10 +35,11 @@ import java.util.Map;
 import static org.intellij.grammar.psi.BnfAttributes.getRootAttribute;
 
 /**
- * Single source of truth for the {@code *OutputPath} BNF attributes: the set of every path
- * attribute, the FQN-attribute ↔ path-attribute pairings, and the BNF-file-parent-relative
- * resolution rules used by every consumer (the build-time {@code BnfGenerationService} and the
- * inlay-hints provider).
+ * Single source of truth for the {@code *InputPath} and {@code *OutputPath} BNF attributes:
+ * the set of every path attribute, the FQN-attribute ↔ path-attribute pairings, and the
+ * BNF-file-parent-relative resolution rules used by every consumer (the IDE's
+ * {@code PsiHelperFactory}, the build-time {@code BnfGenerationService}, and the inlay-hints
+ * provider).
  *
  * <p>Path values are always resolved relative to the BNF file's parent directory.
  */
@@ -54,8 +56,22 @@ public final class BnfPaths {
     KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH,
     KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH);
 
-  /** Every path-valued attribute, in declaration order. */
-  public static final List<KnownAttribute<String>> ALL = OUTPUTS;
+  /** Input-path attributes, in declaration order. */
+  public static final List<KnownAttribute<String>> INPUTS = List.of(
+    KnownAttribute.INPUT_PATH,
+    KnownAttribute.PSI_INPUT_PATH);
+
+  /** Every path-valued attribute (input + output), in declaration order. */
+  public static final List<KnownAttribute<String>> ALL = ContainerUtil.concat(INPUTS, OUTPUTS);
+
+  /**
+   * FQN-attribute → its corresponding {@code *InputPath} sibling. {@code parserUtilClass} has
+   * no specific input override and falls through to the global {@code inputPath}.
+   */
+  public static final Map<KnownAttribute<?>, KnownAttribute<String>> INPUT_FOR = Map.of(
+    KnownAttribute.PSI_IMPL_UTIL_CLASS,  KnownAttribute.PSI_INPUT_PATH,
+    KnownAttribute.MIXIN,                KnownAttribute.PSI_INPUT_PATH,
+    KnownAttribute.IMPLEMENTS,           KnownAttribute.PSI_INPUT_PATH);
 
   /** FQN-attribute → its corresponding {@code *OutputPath} sibling. */
   public static final Map<KnownAttribute<?>, KnownAttribute<String>> OUTPUT_FOR = Map.ofEntries(
@@ -112,12 +128,25 @@ public final class BnfPaths {
 
   /**
    * Builds a {@link BnfPathsResolution} from a partial map of explicit path values, applying
-   * the same output cascade used for real BNF files (see {@link #applyCascade}). Use this from
-   * build-time/CLI/test entry points that have already resolved paths from non-PSI sources
-   * (e.g. command-line flags).
+   * the same input/output cascade used for real BNF files (see {@link #applyCascade}). Use
+   * this from build-time/CLI/test entry points that have already resolved paths from non-PSI
+   * sources (e.g. command-line flags).
    */
   public static @NotNull BnfPathsResolution resolveExplicit(@NotNull Map<KnownAttribute<String>, Path> explicit) {
     return new BnfPathsResolution(applyCascade(explicit));
+  }
+
+  /**
+   * CLI variant of {@link #resolveExplicit(Map)} that also seeds a default for
+   * {@link KnownAttribute#INPUT_PATH}: when neither the CLI nor the grammar provided one, it
+   * defaults to {@code bnfParent}. Mirrors the default applied by {@link #compute} for IDE
+   * editing contexts so headless runs and IDE views agree on the input scope.
+   */
+  public static @NotNull BnfPathsResolution resolveExplicit(@NotNull Map<KnownAttribute<String>, Path> explicit,
+                                                            @NotNull Path bnfParent) {
+    Map<KnownAttribute<String>, Path> seeded = new HashMap<>(explicit);
+    seeded.putIfAbsent(KnownAttribute.INPUT_PATH, bnfParent);
+    return new BnfPathsResolution(applyCascade(seeded));
   }
 
   private static @NotNull BnfPathsResolution compute(@NotNull BnfFile bnfFile) {
@@ -142,6 +171,10 @@ public final class BnfPaths {
       Path inferred = findParserPathInProject(bnfFile, bnfVf);
       if (inferred != null) resolved.put(KnownAttribute.PARSER_OUTPUT_PATH, inferred);
     }
+
+    // inputPath default: when unset, classes referenced in mixin/util attributes are looked up
+    // next to the BNF file. Symmetric to the parserOutputPath inference above.
+    resolved.putIfAbsent(KnownAttribute.INPUT_PATH, parentPath);
 
     Map<KnownAttribute<String>, Path> effectivePaths = applyCascade(resolved);
     return new BnfPathsResolution(effectivePaths);
@@ -170,19 +203,32 @@ public final class BnfPaths {
   }
 
   /**
-   * Bakes the output-path fallback chain into {@code explicit} so direct lookups via
-   * {@link BnfPathsResolution#path} see the effective values.
+   * Bakes both the input- and output-path fallback chains into {@code explicit}, in one pass,
+   * so direct lookups via {@link BnfPathsResolution#path} agree with the on-the-fly cascade
+   * computed by {@link #referencePath}.
    *
-   * <p>Two-level chain rooted at {@code parserOutputPath}: {@code psiOutputPath} →
-   * {@code parserOutputPath}; element-type artifacts ({@code elementTypeHolderOutputPath},
-   * {@code syntaxElementTypeHolderOutputPath}, {@code elementTypeConverterFactoryOutputPath})
-   * → effective {@code psiOutputPath} (which itself may be the parser dir if PSI is unset).
-   * Element-type artifacts travel with PSI rather than the parser, which matters when parser
-   * and PSI live in different source roots (e.g. Kotlin parser + Java PSI). When
-   * {@code parserOutputPath} is unset, no output default is applied.
+   * <p><b>Input cascade.</b> When {@link KnownAttribute#INPUT_PATH global inputPath} is set,
+   * an unset {@code psiInputPath} inherits its value. When {@code inputPath} is unset, no
+   * input default is applied.
+   *
+   * <p><b>Output cascade.</b> Two-level chain rooted at {@code parserOutputPath}:
+   * {@code psiOutputPath} → {@code parserOutputPath}; element-type artifacts
+   * ({@code elementTypeHolderOutputPath}, {@code syntaxElementTypeHolderOutputPath},
+   * {@code elementTypeConverterFactoryOutputPath}) → effective {@code psiOutputPath} (which
+   * itself may be the parser dir if PSI is unset). Element-type artifacts travel with PSI
+   * rather than the parser, which matters when parser and PSI live in different source roots
+   * (e.g. Kotlin parser + Java PSI). When {@code parserOutputPath} is unset, no output
+   * default is applied.
+   *
+   * <p>Input and output cascades touch disjoint key sets, so their order does not matter.
    */
   private static @NotNull Map<KnownAttribute<String>, Path> applyCascade(@NotNull Map<KnownAttribute<String>, Path> explicit) {
     Map<KnownAttribute<String>, Path> next = new HashMap<>(explicit);
+
+    Path inputGlobal = next.get(KnownAttribute.INPUT_PATH);
+    if (inputGlobal != null) {
+      next.putIfAbsent(KnownAttribute.PSI_INPUT_PATH, inputGlobal);
+    }
 
     Path parser = next.get(KnownAttribute.PARSER_OUTPUT_PATH);
     if (parser != null) {
@@ -194,6 +240,40 @@ public final class BnfPaths {
     }
 
     return Map.copyOf(next);
+  }
+
+  /**
+   * Cascade lookup keyed on a class-reference FQN attribute (e.g. {@code mixin},
+   * {@code parserClass}). Used by {@code PsiHelperFactory} to scope reference resolution for
+   * each FQN attribute to the directory tree it points into.
+   * <ol>
+   *   <li>Specific {@code *InputPath} sibling per {@link #INPUT_FOR} — if non-null,
+   *       returned. Otherwise falls through to the global {@code inputPath}.</li>
+   *   <li>Specific {@code *OutputPath} sibling per {@link #OUTPUT_FOR} — resolved via
+   *       {@link BnfPathsResolution#path}. Output attributes do <i>not</i> fall back to the
+   *       global {@code inputPath}.</li>
+   *   <li>Global {@link KnownAttribute#INPUT_PATH} — if non-null, returned.</li>
+   *   <li>Otherwise null.</li>
+   * </ol>
+   */
+  public static @Nullable Path referencePath(@NotNull BnfPathsResolution resolution,
+                                             @Nullable KnownAttribute<?> fqnAttribute) {
+    if (fqnAttribute != null) {
+      KnownAttribute<String> input = INPUT_FOR.get(fqnAttribute);
+      if (input != null) {
+        Path p = resolution.path(input);
+        if (p != null) return p;
+        // fall through to global inputPath
+      }
+      else {
+        KnownAttribute<String> output = OUTPUT_FOR.get(fqnAttribute);
+        if (output != null) {
+          // output attributes do not fall back to the global inputPath default
+          return resolution.path(output);
+        }
+      }
+    }
+    return resolution.path(KnownAttribute.INPUT_PATH);
   }
 
   private static @Nullable Path findParserPathInProject(@NotNull BnfFile bnfFile, VirtualFile bnfVf) {

--- a/bnf-language/src/org/intellij/grammar/BnfPaths.java
+++ b/bnf-language/src/org/intellij/grammar/BnfPaths.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2011-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.intellij.grammar;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.PackageIndex;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.search.FilenameIndex;
+import com.intellij.psi.search.ProjectScope;
+import com.intellij.psi.util.CachedValueProvider;
+import com.intellij.psi.util.CachedValuesManager;
+import com.intellij.psi.util.PsiModificationTracker;
+import com.intellij.util.ArrayUtil;
+import org.intellij.grammar.config.Options;
+import org.intellij.grammar.psi.BnfFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.intellij.grammar.psi.BnfAttributes.getRootAttribute;
+
+/**
+ * Single source of truth for the {@code *OutputPath} BNF attributes: the set of every path
+ * attribute, the FQN-attribute ↔ path-attribute pairings, and the BNF-file-parent-relative
+ * resolution rules used by every consumer (the build-time {@code BnfGenerationService} and the
+ * inlay-hints provider).
+ *
+ * <p>Path values are always resolved relative to the BNF file's parent directory.
+ */
+public final class BnfPaths {
+  private BnfPaths() {
+  }
+
+  /** Output-path attributes, in declaration order. Each one represents a directory the
+   * generator writes to and that callers (CLI, batch service) may need to materialize on disk. */
+  public static final List<KnownAttribute<String>> OUTPUTS = List.of(
+    KnownAttribute.PARSER_OUTPUT_PATH,
+    KnownAttribute.PSI_OUTPUT_PATH,
+    KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH,
+    KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH,
+    KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH);
+
+  /** Every path-valued attribute, in declaration order. */
+  public static final List<KnownAttribute<String>> ALL = OUTPUTS;
+
+  /** FQN-attribute → its corresponding {@code *OutputPath} sibling. */
+  public static final Map<KnownAttribute<?>, KnownAttribute<String>> OUTPUT_FOR = Map.ofEntries(
+    Map.entry(KnownAttribute.PARSER_CLASS,                         KnownAttribute.PARSER_OUTPUT_PATH),
+    Map.entry(KnownAttribute.ELEMENT_TYPE_HOLDER_CLASS,            KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH),
+    Map.entry(KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_CLASS,     KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH),
+    Map.entry(KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_CLASS, KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH),
+    Map.entry(KnownAttribute.PSI_PACKAGE,                          KnownAttribute.PSI_OUTPUT_PATH),
+    Map.entry(KnownAttribute.PSI_IMPL_PACKAGE,                     KnownAttribute.PSI_OUTPUT_PATH));
+
+  private static final Map<String, KnownAttribute<String>> BY_NAME = buildByName();
+
+  private static Map<String, KnownAttribute<String>> buildByName() {
+    Map<String, KnownAttribute<String>> map = new LinkedHashMap<>();
+    for (KnownAttribute<String> a : ALL) map.put(a.getName(), a);
+    return Map.copyOf(map);
+  }
+
+  /** Looks up a path attribute by its BNF-source name; null when {@code name} is not a path attribute. */
+  public static @Nullable KnownAttribute<String> pathAttributeByName(@Nullable String name) {
+    return name == null ? null : BY_NAME.get(name);
+  }
+
+  /**
+   * Resolves {@code relativePath} on disk against the BNF file's parent directory. Pure path
+   * arithmetic; does not touch the VFS or create any directories.
+   */
+  public static @Nullable Path resolveOnDisk(@NotNull BnfFile bnfFile, @NotNull String relativePath) {
+    VirtualFile bnfVf = bnfFile.getOriginalFile().getVirtualFile();
+    if (bnfVf == null) return null;
+    VirtualFile parent = bnfVf.getParent();
+    if (parent == null) return null;
+    try {
+      return Paths.get(parent.getPath()).resolve(relativePath).normalize();
+    }
+    catch (InvalidPathException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Returns the cached {@link BnfPathsResolution} for {@code bnfFile}: every path attribute
+   * resolved against the BNF file's parent, with the parser-class-package fallback for
+   * {@code parserOutputPath} and the full output-path cascade applied.
+   *
+   * <p>Cached via {@link CachedValuesManager}, invalidated by
+   * {@link PsiModificationTracker#MODIFICATION_COUNT}. Read-only — never creates directories.
+   */
+  public static @NotNull BnfPathsResolution resolve(@NotNull BnfFile bnfFile) {
+    return CachedValuesManager.getCachedValue(bnfFile, () -> CachedValueProvider.Result.create(
+      compute(bnfFile),
+      PsiModificationTracker.MODIFICATION_COUNT));
+  }
+
+  /**
+   * Builds a {@link BnfPathsResolution} from a partial map of explicit path values, applying
+   * the same output cascade used for real BNF files (see {@link #applyCascade}). Use this from
+   * build-time/CLI/test entry points that have already resolved paths from non-PSI sources
+   * (e.g. command-line flags).
+   */
+  public static @NotNull BnfPathsResolution resolveExplicit(@NotNull Map<KnownAttribute<String>, Path> explicit) {
+    return new BnfPathsResolution(applyCascade(explicit));
+  }
+
+  private static @NotNull BnfPathsResolution compute(@NotNull BnfFile bnfFile) {
+    VirtualFile bnfVf = bnfFile.getOriginalFile().getVirtualFile();
+    VirtualFile bnfParent = bnfVf == null ? null : bnfVf.getParent();
+    if (bnfParent == null) {
+      return BnfPathsResolution.EMPTY;
+    }
+
+    Path parentPath;
+    try {
+      parentPath = Paths.get(bnfParent.getPath());
+    }
+    catch (InvalidPathException e) {
+      return BnfPathsResolution.EMPTY;
+    }
+
+    Map<KnownAttribute<String>, Path> resolved = collectExplicitPaths(bnfFile, parentPath);
+
+    // parserOutputPath fallback: derive from parserClass package via read-only inference.
+    if (!resolved.containsKey(KnownAttribute.PARSER_OUTPUT_PATH)) {
+      Path inferred = findParserPathInProject(bnfFile, bnfVf);
+      if (inferred != null) resolved.put(KnownAttribute.PARSER_OUTPUT_PATH, inferred);
+    }
+
+    Map<KnownAttribute<String>, Path> effectivePaths = applyCascade(resolved);
+    return new BnfPathsResolution(effectivePaths);
+  }
+
+  /**
+   * Reads every {@link #ALL} path attribute from {@code bnfFile} and resolves each non-empty
+   * value relative to {@code bnfParent}. Pure path arithmetic — does not touch the VFS or
+   * create any directories. Returns a fresh mutable map so callers can layer their own
+   * fallbacks (e.g. a CLI {@code <output-dir>} default for {@code parserOutputPath}) before
+   * passing the result to {@link #resolveExplicit}.
+   */
+  public static @NotNull Map<KnownAttribute<String>, Path> collectExplicitPaths(
+    @NotNull BnfFile bnfFile, @NotNull Path bnfParent) {
+    Map<KnownAttribute<String>, Path> resolved = new HashMap<>();
+    for (KnownAttribute<String> attr : ALL) {
+      String value = getRootAttribute(bnfFile, attr);
+      if (StringUtil.isEmpty(value)) continue;
+      try {
+        resolved.put(attr, bnfParent.resolve(value).normalize());
+      }
+      catch (InvalidPathException ignored) {
+      }
+    }
+    return resolved;
+  }
+
+  /**
+   * Bakes the output-path fallback chain into {@code explicit} so direct lookups via
+   * {@link BnfPathsResolution#path} see the effective values.
+   *
+   * <p>Two-level chain rooted at {@code parserOutputPath}: {@code psiOutputPath} →
+   * {@code parserOutputPath}; element-type artifacts ({@code elementTypeHolderOutputPath},
+   * {@code syntaxElementTypeHolderOutputPath}, {@code elementTypeConverterFactoryOutputPath})
+   * → effective {@code psiOutputPath} (which itself may be the parser dir if PSI is unset).
+   * Element-type artifacts travel with PSI rather than the parser, which matters when parser
+   * and PSI live in different source roots (e.g. Kotlin parser + Java PSI). When
+   * {@code parserOutputPath} is unset, no output default is applied.
+   */
+  private static @NotNull Map<KnownAttribute<String>, Path> applyCascade(@NotNull Map<KnownAttribute<String>, Path> explicit) {
+    Map<KnownAttribute<String>, Path> next = new HashMap<>(explicit);
+
+    Path parser = next.get(KnownAttribute.PARSER_OUTPUT_PATH);
+    if (parser != null) {
+      next.putIfAbsent(KnownAttribute.PSI_OUTPUT_PATH, parser);
+      Path psi = next.get(KnownAttribute.PSI_OUTPUT_PATH);
+      next.putIfAbsent(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH, psi);
+      next.putIfAbsent(KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH, psi);
+      next.putIfAbsent(KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH, psi);
+    }
+
+    return Map.copyOf(next);
+  }
+
+  private static @Nullable Path findParserPathInProject(@NotNull BnfFile bnfFile, VirtualFile bnfVf) {
+    String parserClass = getRootAttribute(bnfFile, KnownAttribute.PARSER_CLASS);
+    if (!StringUtil.isNotEmpty(parserClass)) {
+      return null;
+    }
+
+    return inferTargetDirectory(
+      bnfFile.getProject(),
+      bnfVf,
+      StringUtil.getShortName(parserClass) + ".java",
+      StringUtil.getPackageName(parserClass),
+      true,
+      true
+    );
+  }
+
+  /**
+   * Read-only sibling of {@link org.intellij.grammar.generator.batch.FileGeneratorUtil#getTargetDirectoryFor}: applies the same
+   * root-selection and package-append logic but never invokes a write action and never creates
+   * directories. Returns the would-be absolute {@link Path} as if generation had run, or
+   * {@code null} when a root cannot be guessed.
+   *
+   * <p>This is the inference half shared between {@link #compute} (editor read context, no
+   * creation) and {@code FileGeneratorUtil.getTargetDirectoryFor} (write context, layers a
+   * {@code createDirectoryIfMissing} on top).
+   */
+  public static @Nullable Path inferTargetDirectory(@NotNull Project project,
+                                                    @NotNull VirtualFile sourceFile,
+                                                    @Nullable String targetFile,
+                                                    @Nullable String targetPackage,
+                                                    boolean returnRoot,
+                                                    boolean preferGenRoot) {
+    boolean hasPackage = StringUtil.isNotEmpty(targetPackage);
+    ProjectRootManager rootManager = ProjectRootManager.getInstance(project);
+    PackageIndex packageIndex = PackageIndex.getInstance(project);
+    ProjectFileIndex fileIndex = ProjectFileIndex.getInstance(project);
+
+    VirtualFile existingFile = findExistingFile(project, targetFile, targetPackage, fileIndex, packageIndex);
+    VirtualFile existingFileRoot =
+      existingFile == null ? null :
+      fileIndex.isInSourceContent(existingFile) ? fileIndex.getSourceRootForFile(existingFile) :
+      fileIndex.isInContent(existingFile) ? fileIndex.getContentRootForFile(existingFile) : null;
+
+    boolean preferSourceRoot = hasPackage && !preferGenRoot;
+    VirtualFile[] sourceRoots = rootManager.getContentSourceRoots();
+    VirtualFile[] contentRoots = rootManager.getContentRoots();
+    VirtualFile virtualRoot = existingFileRoot != null ? existingFileRoot :
+                              preferSourceRoot && fileIndex.isInSource(sourceFile) ? fileIndex.getSourceRootForFile(sourceFile) :
+                              fileIndex.isInContent(sourceFile) ? fileIndex.getContentRootForFile(sourceFile) :
+                              ArrayUtil.getFirstElement(preferSourceRoot && sourceRoots.length > 0 ? sourceRoots : contentRoots);
+    if (virtualRoot == null) return null;
+
+    String packagePrefix = StringUtil.notNullize(packageIndex.getPackageNameByDirectory(virtualRoot));
+    String genDirName = Options.GEN_DIR.get();
+    boolean newGenRoot = !fileIndex.isInSourceContent(virtualRoot);
+    String relativePath = (hasPackage && newGenRoot ? genDirName + "/" + targetPackage :
+                           hasPackage ? StringUtil.trimStart(StringUtil.trimStart(targetPackage, packagePrefix), ".") :
+                           newGenRoot ? genDirName : "").replace('.', '/');
+    Path rootPath;
+    try {
+      rootPath = Paths.get(virtualRoot.getPath());
+    }
+    catch (InvalidPathException e) {
+      return null;
+    }
+    if (returnRoot) {
+      return newGenRoot ? rootPath.resolve(genDirName) : rootPath;
+    }
+    return relativePath.isEmpty() ? rootPath : rootPath.resolve(relativePath);
+  }
+
+  private static @Nullable VirtualFile findExistingFile(@NotNull Project project,
+                                                        @Nullable String targetFile,
+                                                        @Nullable String targetPackage,
+                                                        @NotNull ProjectFileIndex fileIndex,
+                                                        @NotNull PackageIndex packageIndex) {
+    if (targetFile == null) return null;
+    Collection<VirtualFile> fromIndex = FilenameIndex.getVirtualFilesByName(targetFile, ProjectScope.getProjectScope(project));
+    List<VirtualFile> files = new ArrayList<>(fromIndex);
+    files.sort((f1, f2) -> {
+      boolean b1 = fileIndex.isInSource(f1);
+      boolean b2 = fileIndex.isInSource(f2);
+      if (b1 != b2) return b1 ? -1 : 1;
+      return Integer.compare(f1.getPath().length(), f2.getPath().length());
+    });
+    for (VirtualFile file : files) {
+      String existingFilePackage = packageIndex.getPackageNameByDirectory(file.getParent());
+      if (StringUtil.isEmpty(targetPackage) || existingFilePackage == null || targetPackage.equals(existingFilePackage)) {
+        return file;
+      }
+    }
+    return null;
+  }
+}

--- a/bnf-language/src/org/intellij/grammar/BnfPathsResolution.java
+++ b/bnf-language/src/org/intellij/grammar/BnfPathsResolution.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2011-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.intellij.grammar;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Immutable snapshot of every {@code *OutputPath} resolution for a single BNF file. Pure data
+ * holder — no inference, no cascade. The map passed in is treated as the fully resolved view:
+ * {@link #path} and {@link #pathString} are direct map lookups.
+ *
+ * <p>Build via {@link BnfPaths#resolve(org.intellij.grammar.psi.BnfFile)} for a real file
+ * (cached) or {@link BnfPaths#resolveExplicit(Map)} for a partial map (applies the
+ * output-path cascade). Construct directly only when the map is already fully resolved.
+ */
+public final class BnfPathsResolution {
+  public static final BnfPathsResolution EMPTY = new BnfPathsResolution(Map.of());
+
+  private final Map<KnownAttribute<String>, Path> myPaths;
+
+  public BnfPathsResolution(@NotNull Map<KnownAttribute<String>, Path> resolvedPaths) {
+    myPaths = Map.copyOf(resolvedPaths);
+  }
+
+  /**
+   * Effective absolute on-disk path for {@code attribute}, or {@code null} when the resolution
+   * has no value for it (typically an output attribute on a resolution that has no
+   * {@code parserOutputPath} root).
+   */
+  public @Nullable Path path(@NotNull KnownAttribute<String> attribute) {
+    return myPaths.get(attribute);
+  }
+
+  /**
+   * Same as {@link #path} but as a string and never null — throws {@link IllegalStateException}
+   * when {@code attribute} has no resolved value. Use this when the caller requires a directory
+   * and a missing one is a programming error (e.g. emitting an output artifact whose owning
+   * attribute must resolve to a directory).
+   */
+  public @NotNull String pathString(@NotNull KnownAttribute<String> attribute) {
+    Path p = myPaths.get(attribute);
+    if (p == null) {
+      throw new IllegalStateException(
+        "No path resolved for attribute '" + attribute.getName() + "'. " +
+        "For output attributes, ensure parserOutputPath is set on the resolution (it acts as the " +
+        "fallback for psi/etHolder/syntax/converter cascades).");
+    }
+    return p.toString();
+  }
+}

--- a/bnf-language/src/org/intellij/grammar/BnfPathsResolution.java
+++ b/bnf-language/src/org/intellij/grammar/BnfPathsResolution.java
@@ -11,9 +11,9 @@ import java.nio.file.Path;
 import java.util.Map;
 
 /**
- * Immutable snapshot of every {@code *OutputPath} resolution for a single BNF file. Pure data
- * holder — no inference, no cascade. The map passed in is treated as the fully resolved view:
- * {@link #path} and {@link #pathString} are direct map lookups.
+ * Immutable snapshot of every {@code *InputPath} / {@code *OutputPath} resolution for a single
+ * BNF file. Pure data holder — no inference, no cascade. The map passed in is treated as the
+ * fully resolved view: {@link #path} and {@link #pathString} are direct map lookups.
  *
  * <p>Build via {@link BnfPaths#resolve(org.intellij.grammar.psi.BnfFile)} for a real file
  * (cached) or {@link BnfPaths#resolveExplicit(Map)} for a partial map (applies the
@@ -30,8 +30,8 @@ public final class BnfPathsResolution {
 
   /**
    * Effective absolute on-disk path for {@code attribute}, or {@code null} when the resolution
-   * has no value for it (typically an output attribute on a resolution that has no
-   * {@code parserOutputPath} root).
+   * has no value for it (typically an input attribute the user didn't set, or an output
+   * attribute on a resolution that has no {@code parserOutputPath} root).
    */
   public @Nullable Path path(@NotNull KnownAttribute<String> attribute) {
     return myPaths.get(attribute);

--- a/bnf-language/src/org/intellij/grammar/KnownAttribute.java
+++ b/bnf-language/src/org/intellij/grammar/KnownAttribute.java
@@ -99,6 +99,12 @@ public class KnownAttribute<T> {
   public static final KnownAttribute<String> SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH     = create(true, String.class, "syntaxElementTypeHolderOutputPath", null);
   public static final KnownAttribute<String> ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH = create(true, String.class, "elementTypeConverterFactoryOutputPath", null);
 
+  // Explicit input source-root overrides; resolved relative to the BNF file's parent. When set,
+  // narrow PsiHelper's findClass scope from "all project" to the named directory. Has no effect on
+  // AsmHelper / ReflectionHelper. null = no narrowing.
+  public static final KnownAttribute<String> INPUT_PATH      = create(true, String.class, "inputPath",     null);
+  public static final KnownAttribute<String> PSI_INPUT_PATH  = create(true, String.class, "psiInputPath",  null);
+
   private final boolean myGlobal;
   private final String myName;
   private final Class<T> myClazz;

--- a/bnf-language/src/org/intellij/grammar/KnownAttribute.java
+++ b/bnf-language/src/org/intellij/grammar/KnownAttribute.java
@@ -87,11 +87,17 @@ public class KnownAttribute<T> {
   public static final KnownAttribute<ListValue>    TOKENS                    = create(true, ListValue.class, "tokens", EMPTY_LIST);
 
   //Syntax api
-  public static final KnownAttribute<String> PSI_OUTPUT_PATH                      = create(true, String.class, "psiOutputPath", "");
   public static final KnownAttribute<String> SYNTAX_ELEMENT_TYPE_HOLDER_CLASS     = create(true, String.class, "syntaxElementTypeHolderClass", "generated.GeneratedSyntaxElementTypes");
   public static final KnownAttribute<String> SYNTAX_ELEMENT_TYPE_FACTORY          = create(false, String.class, "syntaxElementTypeFactory", null);
   public static final KnownAttribute<String> ELEMENT_TYPE_CONVERTER_FACTORY_CLASS = create(true, String.class, "elementTypeConverterFactoryClass", "generated.GeneratedSyntaxElementTypeConverterFactory");
   public static final KnownAttribute<String> SYNTAX_PARSER_UTIL_OBJECT            = create(true, String.class, "syntaxParserUtilObject", "");
+
+  // Explicit output directory overrides; resolved relative to the BNF file's parent. null = derive default location.
+  public static final KnownAttribute<String> PARSER_OUTPUT_PATH                         = create(true, String.class, "parserOutputPath", null);
+  public static final KnownAttribute<String> PSI_OUTPUT_PATH                            = create(true, String.class, "psiOutputPath", null);
+  public static final KnownAttribute<String> ELEMENT_TYPE_HOLDER_OUTPUT_PATH            = create(true, String.class, "elementTypeHolderOutputPath", null);
+  public static final KnownAttribute<String> SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH     = create(true, String.class, "syntaxElementTypeHolderOutputPath", null);
+  public static final KnownAttribute<String> ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH = create(true, String.class, "elementTypeConverterFactoryOutputPath", null);
 
   private final boolean myGlobal;
   private final String myName;

--- a/bnf-language/src/org/intellij/grammar/java/JavaHelper.java
+++ b/bnf-language/src/org/intellij/grammar/java/JavaHelper.java
@@ -40,14 +40,16 @@ import java.util.*;
 public abstract class JavaHelper {
 
   /**
-   * Returns the {@link JavaHelper} to use for the given {@code context}. Inside the IDE this is the
-   * project-level {@link PsiHelper} service registered in {@code plugin-java.xml}. When no service is
-   * available (e.g. light tests, command-line usage), falls back to a fresh {@link AsmHelper} so the
-   * caller still gets bytecode-driven introspection rather than {@code null}.
+   * Returns the {@link JavaHelper} to use for the given {@code context}. Inside the IDE this is a
+   * fresh {@code PsiHelper} produced by the project-level {@code PsiHelperFactory} service
+   * (registered in {@code plugin-java.xml}); the factory bakes a {@code *InputPath}-derived search
+   * scope into the helper based on {@code context}'s position in the BNF tree. When no service is
+   * available (e.g. light tests, command-line usage), falls back to a fresh {@link AsmHelper} so
+   * the caller still gets bytecode-driven introspection rather than {@code null}.
    */
   public static JavaHelper getJavaHelper(@NotNull PsiElement context) {
-    JavaHelper service = context.getProject().getService(JavaHelper.class);
-    return service == null ? new AsmHelper() : service;
+    PsiHelperFactory factory = context.getProject().getService(PsiHelperFactory.class);
+    return factory == null ? new AsmHelper() : factory.getInstance(context);
   }
 
   /**

--- a/bnf-language/src/org/intellij/grammar/java/PsiHelper.java
+++ b/bnf-language/src/org/intellij/grammar/java/PsiHelper.java
@@ -6,15 +6,10 @@ package org.intellij.grammar.java;
 
 import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ProjectFileIndex;
-import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.vfs.VirtualFileUtil;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.source.resolve.reference.impl.providers.JavaClassReferenceProvider;
 import com.intellij.psi.search.GlobalSearchScope;
-import com.intellij.psi.search.GlobalSearchScopesCore;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.ArrayUtil;
 import com.intellij.util.IncorrectOperationException;
@@ -22,8 +17,6 @@ import com.intellij.util.ProcessingContext;
 import com.intellij.util.containers.ContainerUtil;
 import org.intellij.grammar.KnownAttribute;
 import org.intellij.grammar.psi.BnfAttr;
-import org.intellij.grammar.psi.BnfAttributes;
-import org.intellij.grammar.psi.BnfFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -51,10 +44,12 @@ import static org.intellij.grammar.psi.BnfAttributes.getRootAttribute;
 final class PsiHelper extends AsmHelper {
   private final JavaPsiFacade myFacade;
   private final PsiElementFactory myElementFactory;
+  private final @Nullable GlobalSearchScope myScope;
 
-  private PsiHelper(@NotNull Project project) {
+  PsiHelper(@NotNull Project project, @Nullable GlobalSearchScope scope) {
     myFacade = JavaPsiFacade.getInstance(project);
     myElementFactory = PsiElementFactory.getInstance(project);
+    myScope = scope;
   }
 
   private static boolean acceptsMethod(PsiElementFactory elementFactory,
@@ -118,19 +113,8 @@ final class PsiHelper extends AsmHelper {
     JavaClassReferenceProvider provider = new JavaClassReferenceProvider() {
       @Override
       public GlobalSearchScope getScope(@NotNull Project project) {
-        BnfFile bnfFile = (BnfFile)element.getContainingFile();
-        if (BnfAttributes.useSyntaxApi(bnfFile)) {
-          String psiPath = getRootAttribute(element, KnownAttribute.PSI_OUTPUT_PATH);
-          if (psiPath.isEmpty()) return null;
-          ProjectFileIndex fileIndex = ProjectRootManager.getInstance(project).getFileIndex();
-          VirtualFile basePath = fileIndex.getContentRootForFile(bnfFile.getVirtualFile());
-          if (basePath == null) return null;
-          VirtualFile psiRoot = VirtualFileUtil.findDirectory(basePath, psiPath);
-          if (psiRoot == null) return null;
-
-          return GlobalSearchScopesCore.directoriesScope(project, true, psiRoot);
-        }
-        return null;
+        // Honor the *InputPath / *OutputPath cascade resolved by PsiHelperFactory; null = platform default.
+        return myScope;
       }
     };
     provider.setOption(JavaClassReferenceProvider.ALLOW_DOLLAR_NAMES, false);
@@ -165,7 +149,7 @@ final class PsiHelper extends AsmHelper {
   private PsiClass findClassSafe(String className) {
     if (className == null) return null;
     try {
-      return myFacade.findClass(className, GlobalSearchScope.allScope(myFacade.getProject()));
+      return myFacade.findClass(className, myScope != null ? myScope : GlobalSearchScope.allScope(myFacade.getProject()));
     }
     catch (IndexNotReadyException e) {
       return null;

--- a/bnf-language/src/org/intellij/grammar/java/PsiHelperFactory.java
+++ b/bnf-language/src/org/intellij/grammar/java/PsiHelperFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2011-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.intellij.grammar.java;
+
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.GlobalSearchScopesCore;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.intellij.grammar.BnfPaths;
+import org.intellij.grammar.BnfPathsResolution;
+import org.intellij.grammar.KnownAttribute;
+import org.intellij.grammar.psi.BnfAttr;
+import org.intellij.grammar.psi.BnfFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+
+/**
+ * Project-level service that builds {@link PsiHelper} instances tailored to a given context.
+ * <p>
+ * The helper's class-lookup scope is decided once at construction time by walking the context
+ * to find an enclosing {@link BnfAttr} and consulting the cached {@link BnfPathsResolution} for
+ * the file. The resolution applies the full {@code *InputPath} / {@code *OutputPath} cascade
+ * (see {@link BnfPaths#referencePath}), including the global {@code inputPath} fallback for
+ * input attributes.
+ */
+@Service(Service.Level.PROJECT)
+public final class PsiHelperFactory {
+  private final Project myProject;
+
+  public PsiHelperFactory(@NotNull Project project) {
+    myProject = project;
+  }
+
+  public static @NotNull PsiHelperFactory getInstance(@NotNull Project project) {
+    return project.getService(PsiHelperFactory.class);
+  }
+
+  public @NotNull PsiHelper getInstance(@NotNull PsiElement context) {
+    return new PsiHelper(myProject, computeReferenceScope(context));
+  }
+
+  /**
+   * Returns a {@link PsiHelper} whose class-lookup scope is decided by
+   * {@link BnfPaths#referencePath}{@code (paths, fqnAttribute)}. Use this from contexts that
+   * already hold a fully-resolved {@link BnfPathsResolution} (e.g. the build-time
+   * {@code Generator}) to avoid re-resolving via the PSI cache, which may not reflect CLI
+   * overrides or in-flight test fixtures.
+   */
+  public @NotNull PsiHelper getInstance(@NotNull BnfPathsResolution paths,
+                                        @Nullable KnownAttribute<?> fqnAttribute) {
+    Path dir = BnfPaths.referencePath(paths, fqnAttribute);
+    GlobalSearchScope scope = scopeFor(dir);
+    return new PsiHelper(myProject, scope);
+  }
+
+  private @Nullable GlobalSearchScope computeReferenceScope(@NotNull PsiElement context) {
+    BnfFile bnfFile = context.getContainingFile() instanceof BnfFile f ? f : null;
+    if (bnfFile == null) return null;
+
+    BnfAttr enclosingAttr = PsiTreeUtil.getParentOfType(context, BnfAttr.class, false);
+    KnownAttribute<?> fqnAttribute = enclosingAttr == null ? null : KnownAttribute.getAttribute(enclosingAttr.getName());
+    BnfPathsResolution paths = BnfPaths.resolve(bnfFile);
+    return scopeFor(BnfPaths.referencePath(paths, fqnAttribute));
+  }
+
+  private @Nullable GlobalSearchScope scopeFor(@Nullable Path dir) {
+    if (dir == null) return null;
+    VirtualFile vf = VirtualFileManager.getInstance().findFileByNioPath(dir);
+    return vf == null ? null : GlobalSearchScopesCore.directoriesScope(myProject, true, vf);
+  }
+}

--- a/bnf-language/src/org/intellij/grammar/psi/impl/BnfStringRefContributor.java
+++ b/bnf-language/src/org/intellij/grammar/psi/impl/BnfStringRefContributor.java
@@ -25,7 +25,16 @@ class BnfStringRefContributor extends PsiReferenceContributor {
 
   private static final Set<KnownAttribute<?>> RULE_ATTRIBUTES = Set.of(EXTENDS, IMPLEMENTS, RECOVER_WHILE, NAME);
 
-  private static final Set<KnownAttribute<?>> JAVA_CLASS_ATTRIBUTES = Set.of(EXTENDS, IMPLEMENTS, MIXIN);
+  private static final Set<KnownAttribute<?>> JAVA_REFERENCE_ATTRIBUTES = Set.of(
+    EXTENDS, IMPLEMENTS, MIXIN,
+    PARSER_CLASS, PARSER_UTIL_CLASS,
+    PSI_IMPL_UTIL_CLASS, PSI_TREE_UTIL_CLASS,
+    ELEMENT_TYPE_CLASS, ELEMENT_TYPE_HOLDER_CLASS,
+    ELEMENT_TYPE_CONVERTER_FACTORY_CLASS,
+    SYNTAX_ELEMENT_TYPE_HOLDER_CLASS,
+    TOKEN_TYPE_CLASS, STUB_CLASS,
+    PSI_PACKAGE, PSI_IMPL_PACKAGE,
+    ELEMENT_TYPE_FACTORY, SYNTAX_ELEMENT_TYPE_FACTORY, TOKEN_TYPE_FACTORY);
 
   @Override
   public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
@@ -52,8 +61,7 @@ class BnfStringRefContributor extends PsiReferenceContributor {
 
     registrar.registerReferenceProvider(
       psiElement(BnfStringImpl.class).withAncestor(3, psiElement(BnfAttr.class).withName(
-        or(string().endsWith("Class"), string().endsWith("Package"), string().endsWith("TypeFactory"),
-           string().with(oneOf(JAVA_CLASS_ATTRIBUTES))))),
+        string().with(oneOf(JAVA_REFERENCE_ATTRIBUTES)))),
       new PsiReferenceProvider() {
 
         @Override

--- a/docs/output-attributes-overview.md
+++ b/docs/output-attributes-overview.md
@@ -1,0 +1,317 @@
+Per-attribute path overrides — change overview & manual verification
+=====================================================================
+
+This document describes the changes on branch `medvedev/add-output-attributes`
+(now squashed into a single commit on top of `master`) and lists hands-on
+checks you can run from the IDE and from a terminal to confirm the new
+behavior.
+
+What changed
+------------
+
+Before this branch, Grammar-Kit had exactly one attribute that pinned where
+generated code lands — `psiOutputPath` (relative, always under the parser
+output dir). Everything else followed a single `<output-dir>` either passed
+to the headless `Main` CLI as a positional argument or derived in the IDE
+from `parserClass`'s package. Class-lookup for things like `mixin`,
+`parserUtilClass`, etc. used the whole project as scope.
+
+After this branch:
+
+1. **Five path-valued BNF attributes** can be declared in the grammar header.
+   Each one is optional; values are resolved relative to the BNF file's
+   parent directory; an empty string means "unset".
+
+   Outputs (where generated artifacts are written):
+   - `parserOutputPath`
+   - `psiOutputPath`
+   - `elementTypeHolderOutputPath`
+   - `syntaxElementTypeHolderOutputPath`
+   - `elementTypeConverterFactoryOutputPath`
+
+   The output cascade is preserved: an unset child output falls back to its
+   parent (parser → psi → et-holder/syntax/converter). A grammar that sets
+   only `parserOutputPath` behaves exactly as before this branch.
+
+2. **`BnfPaths` / `BnfPathsResolution`** (in `:bnf-language`) is the single
+   source of truth for path resolution, used by the IDE Generate Parser
+   action, the headless `Main` CLI, the new inlay-hints provider, and tests.
+   Resolution is PSI-cached on `PsiModificationTracker.MODIFICATION_COUNT`
+   and never creates directories.
+
+3. **Headless CLI gains a flag-driven form.** New shape:
+
+   ```
+   java ... org.intellij.grammar.Main <grammar-file> [options]
+   ```
+
+   One flag per path attribute (see `README.md` for the full table) plus
+   `--strict-paths` to make CLI/grammar conflicts fatal. The legacy
+   positional form `Main <output-dir> <grammars or patterns>` still works
+   and prints a deprecation warning to stderr. Multiple grammar files are
+   only allowed in the legacy form.
+
+4. **CLI ↔ grammar conflict handling.** Per attribute, CLI wins. When CLI
+   and grammar disagree on the same attribute:
+
+   - default: warning to stderr, CLI value used,
+   - `--strict-paths`: error printed and exit code `1`.
+
+   Attributes set on only one side pass through unchanged.
+
+5. **Editor — declarative inlay hints.** Next to each `*OutputPath` string
+   literal in a `.bnf` file, the IDE shows the absolute on-disk path the
+   value resolves to. Provider:
+   `BnfPathAttributeInlayHintsProvider` (registered in `plugin.xml`,
+   declarative-inlay group `OTHER_GROUP`).
+
+6. **Editor — quick-doc.** Ctrl-Q / Cmd-J on any of the new attributes
+   shows the description from
+   `bnf-language/resources/messages/attributeDescriptions/<attr>.html`.
+
+7. **Editor — Cmd-click on classes in attributes.**
+   `BnfStringRefContributor` now contributes Java-class references for
+   every class-bearing attribute (`parserClass`, `parserUtilClass`,
+   `psiImplUtilClass`, `psiTreeUtilClass`, `elementTypeClass`,
+   `elementTypeHolderClass`, `elementTypeConverterFactoryClass`,
+   `syntaxElementTypeHolderClass`, `tokenTypeClass`, `stubClass`,
+   `psiPackage`, `psiImplPackage`, plus the existing
+   `extends` / `implements` / `mixin`). Navigation to the class works on
+   all of them.
+
+8. **Refactoring.** Path-resolution duplication between
+   `Main`, `BnfGenerationService`, and `FileGeneratorUtil` has been
+   collapsed onto `BnfPaths`. `BatchGenerationContext` now carries one
+   `Map<VirtualFile, VirtualFile>` per output category instead of just
+   parser + psi, and the batch service refreshes every output dir after
+   generation. The previous nested `GrammarPattern` record inside `Main`
+   was promoted to its own top-level file.
+
+9. **Tests.** `BnfPathsResolutionTest`, `OutputPathOverridesTest`, and new
+    `MainTest` cases cover resolution rules, generator routing, CLI
+    parsing, and conflict handling. Existing batch and Java/Kotlin
+    generator tests were updated to the new generator constructor
+    signatures (no positional `outputPath`; pass `BnfPathsResolution`
+    instead).
+
+
+Files of interest (squashed commit `master..HEAD`)
+--------------------------------------------------
+
+- New / single source of truth
+  - `bnf-language/src/org/intellij/grammar/BnfPaths.java`
+  - `bnf-language/src/org/intellij/grammar/BnfPathsResolution.java`
+- Attributes & references
+  - `bnf-language/src/org/intellij/grammar/KnownAttribute.java`
+  - `bnf-language/src/org/intellij/grammar/psi/impl/BnfStringRefContributor.java`
+  - `bnf-language/resources/messages/attributeDescriptions/*.html` (new + edited)
+- Editor surface
+  - `src/org/intellij/grammar/editor/BnfPathAttributeInlayHintsProvider.java`
+  - `resources/META-INF/plugin.xml`
+  - `resources/META-INF/plugin-java.xml`
+- Headless CLI
+  - `generator/src/org/intellij/grammar/Main.java`
+  - `generator/src/org/intellij/grammar/CliArgs.java`
+  - `generator/src/org/intellij/grammar/PathConflicts.java`
+  - `generator/src/org/intellij/grammar/GrammarPattern.java`
+  - `generator/src/org/intellij/grammar/UsageException.java`
+- Generator integration
+  - `generator/src/org/intellij/grammar/generator/Generator.java`
+  - `generator/src/org/intellij/grammar/generator/JavaParserGenerator.java`
+  - `generator/src/org/intellij/grammar/generator/KotlinParserGenerator.java`
+  - `generator/src/org/intellij/grammar/generator/batch/BatchGenerationContext.java`
+  - `generator/src/org/intellij/grammar/generator/batch/BnfGenerationService.java`
+  - `generator/src/org/intellij/grammar/generator/batch/FileGeneratorUtil.java`
+- Tests
+  - `tests/org/intellij/grammar/BnfPathsResolutionTest.java`
+  - `tests/org/intellij/grammar/MainTest.java`
+  - `tests/org/intellij/grammar/generator/OutputPathOverridesTest.java`
+- Docs
+  - `README.md` (new "Headless CLI" section + path-attribute table)
+
+
+Manual verification
+-------------------
+
+The checks below assume a working sandbox IDE (`./gradlew runIde`) and a
+local checkout. Build first if needed:
+
+```
+./gradlew assemble
+```
+
+### A. Automated baseline (run before exploring manually)
+
+```
+./gradlew test
+```
+
+Look for green `MainTest`, `BnfPathsResolutionTest`, and
+`OutputPathOverridesTest` in particular. They cover the bulk of the wiring;
+manual checks below focus on what tests can't reach (UI, navigation,
+multi-directory layout on disk).
+
+### B. Headless CLI — new flag form
+
+1. Pick any small grammar in the repo, e.g. `testData/generator/StubsAndCases.bnf`,
+   or write a minimal one in a temp dir:
+
+   ```
+   mkdir -p /tmp/gk-cli && cd /tmp/gk-cli
+   cat > Demo.bnf <<'EOF'
+   {
+     parserClass="demo.DemoParser"
+     elementTypeHolderClass="demo.DemoTypes"
+     psiPackage="demo.psi"
+     psiImplPackage="demo.psi.impl"
+     psiClassPrefix="X"
+   }
+   root ::= 'a' 'b'
+   foo  ::= 'a' root
+   EOF
+   ```
+
+2. Run the new flag form (use the classpath your build emits — typically the
+   `runtime` classpath of `:generator` plus light-psi-all):
+
+   ```
+   java -cp <grammar-kit-and-deps> org.intellij.grammar.Main \
+        Demo.bnf \
+        --parser-output ./out/parser \
+        --psi-output ./out/psi \
+        --element-type-holder-output ./out/types
+   ```
+
+   Expect:
+   - exit code `0`,
+   - `out/parser/demo/DemoParser.java`,
+   - `out/psi/demo/psi/{XRoot.java,XFoo.java,...}` and
+     `out/psi/demo/psi/impl/{XRootImpl.java,...}`,
+   - `out/types/demo/DemoTypes.java`,
+   - **no** deprecation warning on stderr.
+
+3. Re-run the legacy form and confirm the deprecation warning:
+
+   ```
+   java -cp ... org.intellij.grammar.Main ./out-legacy Demo.bnf
+   ```
+
+   Expect: stderr contains
+   `warning: positional <output-dir> is deprecated; use --parser-output <dir>`,
+   and `out-legacy/demo/DemoParser.java` is generated.
+
+4. Run with no args / unknown flag / two grammars + `--flag`:
+
+   ```
+   java -cp ... org.intellij.grammar.Main                       # exit 0, prints usage
+   java -cp ... org.intellij.grammar.Main --bogus Demo.bnf       # exit 1, "Unknown option"
+   java -cp ... org.intellij.grammar.Main A.bnf B.bnf --parser-output o    # exit 1, "exactly one grammar file"
+   ```
+
+### C. CLI vs grammar conflict
+
+1. Edit `Demo.bnf` to also pin `parserOutputPath`:
+
+   ```
+   {
+     parserClass="demo.DemoParser"
+     parserOutputPath="/tmp/gk-grammar-out"
+     ...
+   }
+   ```
+
+2. Run with a different `--parser-output`:
+
+   ```
+   java -cp ... org.intellij.grammar.Main Demo.bnf \
+        --parser-output /tmp/gk-cli-out
+   ```
+
+   Expect: stderr contains
+   `warning: parserOutputPath: CLI value '/tmp/gk-cli-out' overrides grammar value '/tmp/gk-grammar-out'`,
+   and the file lands in `/tmp/gk-cli-out`.
+
+3. Re-run with `--strict-paths` and confirm exit code `1` plus an `error:`
+   line on stderr; nothing should be written to either directory.
+
+### D. IDE — Generate Parser routes per attribute
+
+1. `./gradlew runIde`.
+2. Open any grammar in the sandbox. In the grammar header, add (paths
+   are relative to the BNF file's parent):
+
+   ```
+   parserOutputPath="../build/gen-parser"
+   psiOutputPath="../build/gen-psi"
+   elementTypeHolderOutputPath="../build/gen-types"
+   ```
+
+3. Right-click the BNF file → **Generate Parser Code**.
+4. Confirm three separate directories appear/refresh in the Project view,
+   with the parser, PSI interfaces+impls, and the element-type holder
+   each landing in its own directory.
+5. Remove `elementTypeHolderOutputPath`, regenerate, and confirm the
+   element-type holder now falls back to the parser dir (cascade).
+
+### E. Cmd-click on classes in attributes
+
+1. Hover over each `mixin` / `parserUtilClass` / `implements` /
+   `parserClass` value — the IDE highlights it as a resolvable Java
+   reference (this exercises the `BnfStringRefContributor` change), and
+   Cmd-click navigates to the class file.
+
+### F. Inlay hints
+
+1. Open a BNF that has any `*OutputPath` declared.
+2. To the right of each path literal, an inline gray hint shows the
+   absolute resolved path, e.g.
+
+   ```
+   parserOutputPath = "../build/gen"   /Users/.../project/build/gen
+   ```
+
+3. Toggle the hint provider via **Settings → Editor → Inlay Hints →
+   Other → Resolved path for path attributes** and confirm hints
+   appear/disappear.
+4. Edit a path string and confirm the hint updates within a typing
+   pause (it's PSI-cache backed).
+
+### G. Quick-doc
+
+1. Place caret on any of: `parserOutputPath`, `psiOutputPath`,
+   `elementTypeHolderOutputPath`, `syntaxElementTypeHolderOutputPath`,
+   `elementTypeConverterFactoryOutputPath`.
+2. Press Ctrl-Q (Linux/Win) or F1 / Cmd-J (Mac). The popup should show
+   the description from
+   `bnf-language/resources/messages/attributeDescriptions/<attr>.html`.
+
+### H. Backward compatibility — grammars with no new attributes
+
+1. Open / regenerate a grammar from `testData/` that uses **only**
+   `parserClass` (and possibly the old `psiOutputPath`).
+2. Confirm output ends up in the same place it did on `master`. Diff the
+   generated tree against pre-branch output if you keep one around — no
+   files should change locations.
+
+### I. Tests touched by the refactor
+
+Beyond running `./gradlew test`, spot-check these files compile and pass
+in the IDE:
+
+- `tests/org/intellij/grammar/BnfPathsResolutionTest.java` — pure
+  resolution semantics: cascade and explicit-map handling.
+- `tests/org/intellij/grammar/MainTest.java` — new cases for
+  legacy/new CLI and conflict modes.
+- `tests/org/intellij/grammar/generator/OutputPathOverridesTest.java` —
+  inspects the `File` argument that `OutputOpener.openOutput` receives,
+  so it isolates path routing from generated content.
+- `tests/org/intellij/grammar/actions/BnfGenerationServiceTest.java`,
+  `tests/org/intellij/grammar/generator/{Java,Kotlin}BnfGeneratorTest.java`,
+  `BnfGeneratorPsiTest.java` — updated to the new generator
+  constructor signatures and the wider `BatchGenerationContext` shape;
+  they should still pass without further changes.
+
+If any of B–H surfaces a regression, the most likely suspects are
+`BnfPaths.compute`/`applyCascade` (resolution semantics) and
+`BnfGenerationService.prepareContext` / `ensureDirectory` (where
+absolute on-disk paths are turned into VirtualFiles for the IDE).

--- a/generator/src/org/intellij/grammar/CliArgs.java
+++ b/generator/src/org/intellij/grammar/CliArgs.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2011-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.intellij.grammar;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.PrintStream;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Parsed CLI invocation. {@code paths} holds explicit absolute path overrides keyed by
+ * the corresponding {@link KnownAttribute}; {@code grammarPatterns} are the grammar-file
+ * arguments (one entry under the new form, one or more under the legacy form).
+ */
+record CliArgs(@NotNull Map<KnownAttribute<String>, Path> paths,
+               @NotNull List<String> grammarPatterns,
+               boolean strictPaths) {
+
+  static CliArgs parse(@NotNull String[] args, @NotNull PrintStream out, @NotNull PrintStream err) throws UsageException {
+    if (args.length == 0) {
+      throw new UsageException(0, null);
+    }
+
+    boolean hasFlag = false;
+    for (String a : args) {
+      if (a.startsWith("--")) {
+        hasFlag = true;
+        break;
+      }
+    }
+
+    if (!hasFlag) {
+      if (args.length == 1) {
+        if (!looksLikeGrammar(args[0])) {
+          throw new UsageException(0, null);
+        }
+        return parseNew(args);
+      }
+      if (!looksLikeGrammar(args[0])) {
+        err.println("warning: positional <output-dir> is deprecated; use --parser-output <dir>");
+        return parseLegacy(args);
+      }
+    }
+    return parseNew(args);
+  }
+
+  private static boolean looksLikeGrammar(@NotNull String arg) {
+    if (arg.startsWith("--")) return false;
+    String lower = arg.toLowerCase();
+    // Pattern-based detection (extension only, never file existence): callers may pass globs
+    // like "*.bnf", and existence-based detection misclassifies non-grammar files passed as
+    // legacy <output-dir>.
+    return lower.endsWith(".bnf") || lower.endsWith(".pg");
+  }
+
+  private static CliArgs parseLegacy(@NotNull String[] args) throws UsageException {
+    Map<KnownAttribute<String>, Path> paths = new LinkedHashMap<>();
+    paths.put(KnownAttribute.PARSER_OUTPUT_PATH, toAbsolute(args[0]));
+    List<String> patterns = new java.util.ArrayList<>();
+    for (int i = 1; i < args.length; i++) patterns.add(args[i]);
+    return new CliArgs(Map.copyOf(paths), List.copyOf(patterns), false);
+  }
+
+  private static CliArgs parseNew(@NotNull String[] args) throws UsageException {
+    Map<KnownAttribute<String>, Path> paths = new LinkedHashMap<>();
+    List<String> positionals = new java.util.ArrayList<>();
+    boolean strict = false;
+
+    int i = 0;
+    while (i < args.length) {
+      String a = args[i];
+      if ("--strict-paths".equals(a)) {
+        strict = true;
+        i++;
+        continue;
+      }
+      KnownAttribute<String> attr = Main.FLAG_TO_ATTR.get(a);
+      if (attr != null) {
+        if (i + 1 >= args.length) {
+          throw new UsageException(1, "Missing value for " + a);
+        }
+        paths.put(attr, toAbsolute(args[i + 1]));
+        i += 2;
+        continue;
+      }
+      if (a.startsWith("--")) {
+        throw new UsageException(1, "Unknown option: " + a);
+      }
+      positionals.add(a);
+      i++;
+    }
+
+    if (positionals.isEmpty()) {
+      throw new UsageException(0, null);
+    }
+    if (positionals.size() > 1) {
+      throw new UsageException(1, "Expected exactly one grammar file in new form, got " + positionals.size() +
+                                  "; legacy multi-grammar form does not accept --flags.");
+    }
+    return new CliArgs(Map.copyOf(paths), List.copyOf(positionals), strict);
+  }
+
+  private static @NotNull Path toAbsolute(@NotNull String value) throws UsageException {
+    try {
+      return Paths.get(value).toAbsolutePath().normalize();
+    }
+    catch (InvalidPathException e) {
+      throw new UsageException(1, "Invalid path: " + value);
+    }
+  }
+}

--- a/generator/src/org/intellij/grammar/GrammarPattern.java
+++ b/generator/src/org/intellij/grammar/GrammarPattern.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2011-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.intellij.grammar;
+
+import com.intellij.openapi.util.text.StringUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+record GrammarPattern(
+  @NotNull File grammarDir,
+  @NotNull Pattern grammarPattern,
+  @NotNull String wildCard
+) {
+
+  @NotNull List<File> collectGrammarFiles() {
+    File[] files = grammarDir.listFiles();
+    if (files == null) return List.of();
+
+    return Stream.of(files)
+      .filter(f -> !f.isDirectory() && grammarPattern.matcher(f.getName()).matches())
+      .toList();
+  }
+
+  boolean isValid() {
+    return grammarDir.exists() && grammarDir.isDirectory();
+  }
+
+  static @NotNull GrammarPattern of(@NotNull String grammar) {
+    int idx = grammar.lastIndexOf(File.separator);
+    File grammarDir = new File(idx >= 0 ? grammar.substring(0, idx) : ".");
+    String wildCard = idx >= 0 ? grammar.substring(idx + 1) : grammar;
+    Pattern grammarPattern = Pattern.compile(convertToJavaPattern(wildCard));
+    return new GrammarPattern(grammarDir, grammarPattern, wildCard);
+  }
+
+  private static @NotNull String convertToJavaPattern(@NotNull String wildcardPattern) {
+    wildcardPattern = StringUtil.replace(wildcardPattern, ".", "\\.");
+    wildcardPattern = StringUtil.replace(wildcardPattern, "*?", ".+");
+    wildcardPattern = StringUtil.replace(wildcardPattern, "?*", ".+");
+    wildcardPattern = StringUtil.replace(wildcardPattern, "*", ".*");
+    wildcardPattern = StringUtil.replace(wildcardPattern, "?", ".");
+    return wildcardPattern;
+  }
+}

--- a/generator/src/org/intellij/grammar/Main.java
+++ b/generator/src/org/intellij/grammar/Main.java
@@ -1,12 +1,11 @@
 /*
- * Copyright 2011-2025 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2011-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package org.intellij.grammar;
 
 import com.intellij.lang.LanguageASTFactory;
 import com.intellij.lang.LanguageBraceMatching;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.impl.DebugUtil;
 import org.intellij.grammar.generator.JavaParserGenerator;
@@ -16,25 +15,41 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Command-line interface to parser generator.
  * Required community jars on classpath:
  * app-client.jar, lib-client.jar, opentelemetry.jar, util.jar, util-8.jar, util_rt.jar
  *
+ * <p>New form: {@code generate <grammar-file> [options]}.<br>
+ * Legacy form: {@code generate <output-dir> <grammars or patterns>} (deprecated).
+ *
  * @author gregsh
  * @noinspection UseOfSystemOutOrSystemErr
  */
 public class Main {
-  private final @NotNull BnfParserDefinition parserDefinition;
-  private final @NotNull File output;
+  static final Map<String, KnownAttribute<String>> FLAG_TO_ATTR = buildFlagMap();
 
-  Main(@NotNull BnfParserDefinition parserDefinition, @NotNull File output) {
+  private static Map<String, KnownAttribute<String>> buildFlagMap() {
+    Map<String, KnownAttribute<String>> map = new LinkedHashMap<>();
+    map.put("--parser-output",                          KnownAttribute.PARSER_OUTPUT_PATH);
+    map.put("--psi-output",                             KnownAttribute.PSI_OUTPUT_PATH);
+    map.put("--element-type-holder-output",             KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH);
+    map.put("--syntax-element-type-holder-output",      KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH);
+    map.put("--element-type-converter-factory-output",  KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH);
+    return Map.copyOf(map);
+  }
+
+  private final @NotNull BnfParserDefinition parserDefinition;
+  private final @NotNull CliArgs cliArgs;
+
+  Main(@NotNull BnfParserDefinition parserDefinition, @NotNull CliArgs cliArgs) {
     this.parserDefinition = parserDefinition;
-    this.output = output;
+    this.cliArgs = cliArgs;
   }
 
   public static void main(String[] args) {
@@ -44,31 +59,45 @@ public class Main {
 
   @SuppressWarnings("CallToPrintStackTrace")
   static int run(String[] args) {
+    CliArgs cliArgs;
     try {
-      if (args.length < 2) {
-        System.out.println("Usage: Main <output-dir> <grammars or patterns>");
-        return 0;
-      }
-      String outputPath = args[0];
-      File output = new File(outputPath);
-      if (!output.exists() && !output.mkdirs() || output.isFile()) {
-        System.out.println("Output directory not found: " + output.getAbsolutePath());
-        return 0;
-      }
+      cliArgs = CliArgs.parse(args, System.out, System.err);
+    }
+    catch (UsageException e) {
+      if (e.getMessage() != null) System.err.println(e.getMessage());
+      printUsage(System.out);
+      return e.exitCode;
+    }
 
+    Path parserOutput = cliArgs.paths().get(KnownAttribute.PARSER_OUTPUT_PATH);
+    if (parserOutput != null) {
+      File parserOutputFile = parserOutput.toFile();
+      if (parserOutputFile.exists() && parserOutputFile.isFile()) {
+        System.out.println("Output directory not found: " + parserOutputFile.getAbsolutePath());
+        return 0;
+      }
+      if (!parserOutputFile.exists() && !parserOutputFile.mkdirs()) {
+        System.err.println("Could not create output directory: " + parserOutputFile.getAbsolutePath());
+        return 1;
+      }
+    }
+
+    try {
       LightPsi.init();
       LightPsi.Init.addKeyedExtension(LanguageASTFactory.INSTANCE, BnfLanguage.INSTANCE, new BnfASTFactory(), null);
       LightPsi.Init.addKeyedExtension(LanguageBraceMatching.INSTANCE, BnfLanguage.INSTANCE, new BnfBraceMatcher(), null);
 
-      BnfParserDefinition parserDefinition = new BnfParserDefinition();
-
-      var main = new Main(parserDefinition, output);
-      for (int i = 1; i < args.length; i++) {
-        if (!main.processGrammarFile(args[i])) {
+      var main = new Main(new BnfParserDefinition(), cliArgs);
+      for (String pattern : cliArgs.grammarPatterns()) {
+        if (!main.processGrammarFile(pattern)) {
           return 1;
         }
       }
       return 0;
+    }
+    catch (PathConflicts.ConflictException e) {
+      // already printed; just exit
+      return 1;
     }
     catch (Throwable throwable) {
       throwable.printStackTrace();
@@ -76,10 +105,21 @@ public class Main {
     }
   }
 
+  private static void printUsage(@NotNull PrintStream out) {
+    out.println("Usage: Main <grammar-file> [options]");
+    out.println("Options:");
+    for (Map.Entry<String, KnownAttribute<String>> e : FLAG_TO_ATTR.entrySet()) {
+      out.println("  " + e.getKey() + " <path>   sets " + e.getValue().getName());
+    }
+    out.println("  --strict-paths            fail on CLI/grammar path conflicts");
+    out.println();
+    out.println("Legacy form (deprecated): Main <output-dir> <grammars or patterns>");
+  }
+
   private boolean processGrammarFile(@NotNull String grammar) throws IOException, ClassNotFoundException {
     var grammarPattern = GrammarPattern.of(grammar);
     if (!grammarPattern.isValid()) {
-      System.err.println("Grammar directory not found: " + grammarPattern.grammarDir.getAbsolutePath());
+      System.err.println("Grammar directory not found: " + grammarPattern.grammarDir().getAbsolutePath());
       return false;
     }
 
@@ -87,14 +127,16 @@ public class Main {
 
     int count = 0;
     for (File grammarFile : grammarFiles) {
-      if (generateGrammar(grammarFile, grammarPattern.grammarDir)) {
-        System.out.println(grammarFile.getName() + " parser generated to " + output.getCanonicalPath());
+      if (generateGrammar(grammarFile, grammarPattern.grammarDir())) {
+        Path parserOut = cliArgs.paths().get(KnownAttribute.PARSER_OUTPUT_PATH);
+        String outDesc = parserOut != null ? parserOut.toString() : "(grammar-defined paths)";
+        System.out.println(grammarFile.getName() + " parser generated to " + outDesc);
         count++;
       }
     }
 
     if (count == 0) {
-      System.out.println("No grammars matching '" + grammarPattern.wildCard + "' found in: " + grammarPattern.grammarDir);
+      System.out.println("No grammars matching '" + grammarPattern.wildCard() + "' found in: " + grammarPattern.grammarDir());
     }
 
     return true;
@@ -104,8 +146,8 @@ public class Main {
     PsiFile bnfFile = LightPsi.parseFile(grammarFile, parserDefinition);
     if (!(bnfFile instanceof BnfFile)) return false;
 
-    // for light-psi-all building:
-    if (output.getAbsolutePath().contains("lightpsi")) {
+    Path parserOutput = cliArgs.paths().get(KnownAttribute.PARSER_OUTPUT_PATH);
+    if (parserOutput != null && parserOutput.toString().contains("lightpsi")) {
       Class.forName("org.jetbrains.annotations.NotNull");
       Class.forName("org.jetbrains.annotations.Nullable");
       Class.forName("org.intellij.lang.annotations.Pattern");
@@ -113,49 +155,17 @@ public class Main {
       DebugUtil.psiToString(bnfFile, false);
     }
 
+    Path bnfParent = grammarFile.getParentFile().toPath();
+    Map<KnownAttribute<String>, Path> grammarMap = BnfPaths.collectExplicitPaths((BnfFile)bnfFile, bnfParent);
+    Map<KnownAttribute<String>, Path> merged = PathConflicts.merge(cliArgs.paths(), grammarMap, cliArgs.strictPaths(), System.err);
+    BnfPathsResolution paths = BnfPaths.resolveExplicit(merged);
+
     JavaParserGenerator generator = new JavaParserGenerator((BnfFile)bnfFile,
                                                             grammarDir.getAbsolutePath(),
-                                                            output.getAbsolutePath(),
                                                             "",
-                                                            OutputOpener.DEFAULT);
+                                                            OutputOpener.DEFAULT,
+                                                            paths);
     generator.generate();
     return true;
-  }
-
-  private record GrammarPattern(
-    @NotNull File grammarDir,
-    @NotNull Pattern grammarPattern,
-    @NotNull String wildCard
-  ) {
-
-    @NotNull List<File> collectGrammarFiles() {
-      File[] files = grammarDir.listFiles();
-      if (files == null) return List.of();
-
-      return Stream.of(files)
-        .filter(f -> !f.isDirectory() && grammarPattern.matcher(f.getName()).matches())
-        .toList();
-    }
-
-    boolean isValid() {
-      return grammarDir.exists() && grammarDir.isDirectory();
-    }
-
-    static @NotNull Main.GrammarPattern of(@NotNull String grammar) {
-      int idx = grammar.lastIndexOf(File.separator);
-      File grammarDir = new File(idx >= 0 ? grammar.substring(0, idx) : ".");
-      String wildCard = idx >= 0 ? grammar.substring(idx + 1) : grammar;
-      Pattern grammarPattern = Pattern.compile(convertToJavaPattern(wildCard));
-      return new GrammarPattern(grammarDir, grammarPattern, wildCard);
-    }
-
-    private static @NotNull String convertToJavaPattern(@NotNull String wildcardPattern) {
-      wildcardPattern = StringUtil.replace(wildcardPattern, ".", "\\.");
-      wildcardPattern = StringUtil.replace(wildcardPattern, "*?", ".+");
-      wildcardPattern = StringUtil.replace(wildcardPattern, "?*", ".+");
-      wildcardPattern = StringUtil.replace(wildcardPattern, "*", ".*");
-      wildcardPattern = StringUtil.replace(wildcardPattern, "?", ".");
-      return wildcardPattern;
-    }
   }
 }

--- a/generator/src/org/intellij/grammar/Main.java
+++ b/generator/src/org/intellij/grammar/Main.java
@@ -41,6 +41,8 @@ public class Main {
     map.put("--element-type-holder-output",             KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH);
     map.put("--syntax-element-type-holder-output",      KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH);
     map.put("--element-type-converter-factory-output",  KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH);
+    map.put("--input-path",                             KnownAttribute.INPUT_PATH);
+    map.put("--psi-input",                              KnownAttribute.PSI_INPUT_PATH);
     return Map.copyOf(map);
   }
 
@@ -158,7 +160,7 @@ public class Main {
     Path bnfParent = grammarFile.getParentFile().toPath();
     Map<KnownAttribute<String>, Path> grammarMap = BnfPaths.collectExplicitPaths((BnfFile)bnfFile, bnfParent);
     Map<KnownAttribute<String>, Path> merged = PathConflicts.merge(cliArgs.paths(), grammarMap, cliArgs.strictPaths(), System.err);
-    BnfPathsResolution paths = BnfPaths.resolveExplicit(merged);
+    BnfPathsResolution paths = BnfPaths.resolveExplicit(merged, bnfParent);
 
     JavaParserGenerator generator = new JavaParserGenerator((BnfFile)bnfFile,
                                                             grammarDir.getAbsolutePath(),

--- a/generator/src/org/intellij/grammar/PathConflicts.java
+++ b/generator/src/org/intellij/grammar/PathConflicts.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2011-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.intellij.grammar;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Merges CLI-supplied path overrides with paths declared in the grammar file.
+ * Per-path semantics: CLI wins on collision. When both sides set the same attribute to
+ * different absolute paths, a conflict is reported. In strict mode, conflicts abort
+ * generation; otherwise they are printed as warnings and the CLI value takes effect.
+ */
+final class PathConflicts {
+  private PathConflicts() {
+  }
+
+  /**
+   * Merge {@code cli} into {@code grammar}. Attributes only on one side pass through
+   * unchanged. Attributes on both sides with equal {@link Path}s pass through silently.
+   * Attributes on both sides with different paths produce a warning (strict=false) or a
+   * thrown {@link ConflictException} after all conflicts have been printed (strict=true).
+   */
+  public static @NotNull Map<KnownAttribute<String>, Path> merge(@NotNull Map<KnownAttribute<String>, Path> cli,
+                                                                 @NotNull Map<KnownAttribute<String>, Path> grammar,
+                                                                 boolean strict,
+                                                                 @NotNull PrintStream warnSink) {
+    List<String> conflicts = new ArrayList<>();
+    Map<KnownAttribute<String>, Path> merged = new HashMap<>(grammar);
+    for (Map.Entry<KnownAttribute<String>, Path> e : cli.entrySet()) {
+      KnownAttribute<String> attr = e.getKey();
+      Path cliPath = e.getValue();
+      Path grammarPath = grammar.get(attr);
+      if (grammarPath != null && !grammarPath.equals(cliPath)) {
+        String msg = attr.getName() + ": CLI value '" + cliPath + "' overrides grammar value '" + grammarPath + "'";
+        conflicts.add(msg);
+        if (!strict) warnSink.println("warning: " + msg);
+      }
+      merged.put(attr, cliPath);
+    }
+    if (strict && !conflicts.isEmpty()) {
+      for (String c : conflicts) warnSink.println("error: " + c);
+      throw new ConflictException(conflicts);
+    }
+    return merged;
+  }
+
+  public static final class ConflictException extends RuntimeException {
+    private final List<String> conflicts;
+
+    ConflictException(@NotNull List<String> conflicts) {
+      super("path conflicts in --strict-paths mode: " + conflicts.size());
+      this.conflicts = List.copyOf(conflicts);
+    }
+
+    public @NotNull List<String> conflicts() {
+      return conflicts;
+    }
+  }
+}

--- a/generator/src/org/intellij/grammar/UsageException.java
+++ b/generator/src/org/intellij/grammar/UsageException.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2011-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.intellij.grammar;
+
+final class UsageException extends Exception {
+  final int exitCode;
+
+  UsageException(int exitCode, String message) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}

--- a/generator/src/org/intellij/grammar/generator/ExpressionGeneratorHelper.java
+++ b/generator/src/org/intellij/grammar/generator/ExpressionGeneratorHelper.java
@@ -24,14 +24,36 @@ import static org.intellij.grammar.generator.ParserGeneratorUtil.quote;
 import static org.intellij.grammar.psi.BnfAttributes.getAttribute;
 
 /**
- * @author greg
+ * Java-target emitter for operator-precedence (expression) rules.
+ * <p>
+ * BNF expression rules — those marked via {@link ExpressionInfo} — can't be parsed by the
+ * straight recursive descent that {@link Generator#generateNode} produces; they need
+ * precedence climbing. This helper renders the precedence-climbing parser for one such rule:
+ * a recursive entry function that consumes atoms and prefix operators, a kernel loop that
+ * left-folds binary/n-ary/postfix operators while respecting priority and right-associativity,
+ * and per-operator helper functions. {@link KotlinParserGenerator#generateExpressionRoot} is
+ * the Kotlin counterpart; the two share concept but not code.
+ * <p>
+ * Methods are static — instances are never created. {@link #fixForcedConsumeType} and
+ * {@link #getInfoForExpressionParsing} also serve as cross-module hooks used by the regular
+ * node emitters when they encounter rules participating in an expression.
  */
-public class ExpressionGeneratorHelper {
+public final class ExpressionGeneratorHelper {
 
+  /**
+   * Consume type forced inside expression rules. {@code SMART} is used so that the runtime
+   * uses the {@code consumeTokenSmart} family of methods, which is required to avoid spurious
+   * "expected X" errors during precedence climbing where many alternatives are tried.
+   */
   static final ConsumeType CONSUME_TYPE_OVERRIDE = ConsumeType.SMART;
 
-  private static @NotNull Map<String, List<OperatorInfo>> buildCallMap(ExpressionInfo info,
-                                                                       JavaParserGenerator g,
+  /**
+   * Groups every operator of {@code info}'s expression rule by the rendered text of its
+   * opening operator call. Operators that share an opening token end up in the same kernel-loop
+   * branch, which is how the generator picks the highest-priority match among ambiguous starts.
+   */
+  private static @NotNull Map<String, List<OperatorInfo>> buildCallMap(@NotNull ExpressionInfo info,
+                                                                       @NotNull JavaParserGenerator g,
                                                                        @NotNull NameRenderer R) {
     Map<String, List<OperatorInfo>> opCalls = new LinkedHashMap<>();
     for (BnfRule rule : info.priorityMap.keySet()) {
@@ -45,7 +67,24 @@ public class ExpressionGeneratorHelper {
     return opCalls;
   }
 
-  public static void generateExpressionRoot(ExpressionInfo info, JavaParserGenerator g, @NotNull NameRenderer R) {
+  /**
+   * Emits the full Java parser for one expression rule:
+   * <ol>
+   *   <li>The entry function {@code <rule>(builder, level, priority)} — consumes atoms and
+   *       prefix operators, then delegates to the kernel.</li>
+   *   <li>The kernel function {@code <rule>_0(...)} — a {@code while(true)} loop over
+   *       binary/n-ary/postfix operators, gated on {@code priority < operatorPriority} (with
+   *       right-associativity decreasing the bound by one) and on {@code leftMarkerIs(...)}
+   *       when {@code arg1} restricts the left-hand element type.</li>
+   *   <li>Per-operator helpers — atom rule bodies via {@link Generator#generateNode}, and
+   *       dedicated functions for prefix operators since they need their own section + recursion
+   *       into the entry function with the right priority.</li>
+   * </ol>
+   * Warns when multiple operators share a starting opCall: only the first definition wins.
+   */
+  public static void generateExpressionRoot(@NotNull ExpressionInfo info,
+                                            @NotNull JavaParserGenerator g,
+                                            @NotNull NameRenderer R) {
     Map<String, List<OperatorInfo>> opCalls = buildCallMap(info, g, R);
     Set<String> sortedOpCalls = opCalls.keySet();
 
@@ -207,6 +246,7 @@ public class ExpressionGeneratorHelper {
     }
   }
 
+  /** Returns the subset of {@code operatorInfos} whose {@link OperatorInfo#type()} is one of {@code types}, preserving input order. */
   public static @NotNull List<OperatorInfo> findOperators(@NotNull Collection<OperatorInfo> operatorInfos, OperatorType... types) {
     final var result = new SmartList<OperatorInfo>();
     for (OperatorInfo o : operatorInfos) {
@@ -217,7 +257,13 @@ public class ExpressionGeneratorHelper {
     return result;
   }
 
-  public static @Nullable ExpressionInfo getInfoForExpressionParsing(ExpressionHelper expressionHelper, BnfRule rule) {
+  /**
+   * If a call to {@code rule} should go through the precedence-climbing entry instead of a
+   * direct method call, returns the enclosing {@link ExpressionInfo}; otherwise {@code null}.
+   * Atoms and prefix operators stay on the direct path because the kernel loop already calls
+   * the entry recursively for their right-hand sides.
+   */
+  public static @Nullable ExpressionInfo getInfoForExpressionParsing(@NotNull ExpressionHelper expressionHelper, @Nullable BnfRule rule) {
     final var expressionInfo = expressionHelper.getExpressionInfo(rule);
     final var operatorInfo = expressionInfo == null ? null : expressionInfo.operatorMap.get(rule);
     if (expressionInfo != null && (operatorInfo == null || operatorInfo.type() != OperatorType.ATOM &&
@@ -227,6 +273,12 @@ public class ExpressionGeneratorHelper {
     return null;
   }
 
+  /**
+   * Decides whether the consume type for {@code node} (or for the rule itself, when
+   * {@code node} is {@code null}) should be forced to {@link #CONSUME_TYPE_OVERRIDE} because
+   * it lives inside an expression-rule operator. {@code defValue} short-circuits the check
+   * when a caller has already resolved the consume type.
+   */
   static @Nullable ConsumeType fixForcedConsumeType(@NotNull ExpressionHelper expressionHelper,
                                                     @NotNull BnfRule rule,
                                                     @Nullable BnfExpression node,

--- a/generator/src/org/intellij/grammar/generator/ExpressionHelper.java
+++ b/generator/src/org/intellij/grammar/generator/ExpressionHelper.java
@@ -36,6 +36,9 @@ import static org.intellij.grammar.psi.BnfRules.getSuperRules;
  * @author gregsh
  */
 public class ExpressionHelper {
+  private static final Key<CachedValue<ExpressionHelper>> EXPRESSION_HELPER_KEY = Key.create("EXPRESSION_HELPER_KEY");
+  private static final Key<List<BnfExpression>> ORIGINAL_EXPRESSIONS = Key.create("ORIGINAL_EXPRESSIONS");
+
   private final BnfFile myFile;
   private final RuleGraphHelper myRuleGraph;
   private final Consumer<String> myWarningConsumer;
@@ -43,7 +46,6 @@ public class ExpressionHelper {
   private final Map<BnfRule, ExpressionInfo> myExpressionMap = new HashMap<>();
   private final Map<BnfRule, BnfRule> myRootRulesMap = new HashMap<>();
 
-  private static final Key<CachedValue<ExpressionHelper>> EXPRESSION_HELPER_KEY = Key.create("EXPRESSION_HELPER_KEY");
   public static ExpressionHelper getCached(@NotNull BnfFile file) {
     CachedValue<ExpressionHelper> value = file.getUserData(EXPRESSION_HELPER_KEY);
     if (value == null) {
@@ -52,7 +54,6 @@ public class ExpressionHelper {
     }
     return value.getValue();
   }
-
 
   public ExpressionHelper(BnfFile file, RuleGraphHelper ruleGraph, @Nullable Consumer<String> warningConsumer) {
     myFile = file;
@@ -93,7 +94,8 @@ public class ExpressionHelper {
         myRootRulesMap.put(rule, rule);
         myExpressionMap.put(rule, expressionInfo);
       }
-      ops: for (OperatorInfo info : expressionInfo.operatorMap.values()) {
+      ops:
+      for (OperatorInfo info : expressionInfo.operatorMap.values()) {
         Map<PsiElement, RuleGraphHelper.Cardinality> map = myRuleGraph.collectMembers(info.rule(), info.operator(), new HashSet<>());
         for (RuleGraphHelper.Cardinality c : map.values()) {
           if (!c.optional()) continue ops;
@@ -174,7 +176,7 @@ public class ExpressionHelper {
         info = new OperatorInfo(rule, OperatorType.POSTFIX, combine(childExpressions.subList(1, childExpressions.size())), null, arg1, null);
       }
       else if (index == -1) {
-        addWarning(rule +": " + rootRuleName + " reference not found, treating as ATOM");
+        addWarning(rule + ": " + rootRuleName + " reference not found, treating as ATOM");
         info = new OperatorInfo(rule, OperatorType.ATOM, rule.getExpression(), null);
       }
       else {
@@ -187,7 +189,7 @@ public class ExpressionHelper {
       int index1 = indexOf(rootRuleSubst, 0, childExpressions, expressionInfo);
       int index2 = indexOf(rootRuleSubst, 1, childExpressions, expressionInfo);
       if (index1 != 0) {
-        addWarning(rule +": binary or n-ary expression cannot have prefix, treating as ATOM");
+        addWarning(rule + ": binary or n-ary expression cannot have prefix, treating as ATOM");
         info = new OperatorInfo(rule, OperatorType.ATOM, rule.getExpression(), null);
       }
       else if (index2 == 1) {
@@ -207,7 +209,7 @@ public class ExpressionHelper {
           int index3 = indexOf(rootRuleSubst, 0, childExpressions2, expressionInfo);
           if (badNAry || index3 == -1) {
             addWarning(
-                rule + ": '" + rootRuleName + " ( <op> " + rootRuleName + ") +' expected for N-ary operator, treating as POSTFIX"
+              rule + ": '" + rootRuleName + " ( <op> " + rootRuleName + ") +' expected for N-ary operator, treating as POSTFIX"
             );
             info = new OperatorInfo(rule, OperatorType.POSTFIX, combine(childExpressions.subList(1, childExpressions.size())), null,
                                     arg1, null);
@@ -226,7 +228,7 @@ public class ExpressionHelper {
       }
     }
     else {
-      addWarning(rule +": unexpected cardinality " + cardinality + " of " + rootRuleName +", treating as ATOM");
+      addWarning(rule + ": unexpected cardinality " + cardinality + " of " + rootRuleName + ", treating as ATOM");
       info = new OperatorInfo(rule, OperatorType.ATOM, rule.getExpression(), null);
     }
     expressionInfo.operatorMap.put(rule, info);
@@ -235,10 +237,9 @@ public class ExpressionHelper {
   private @Nullable BnfRule substRule(List<BnfExpression> list, int idx, BnfRule rootRule) {
     if (idx < 0) return null;
     BnfRule rule = myFile.getRule(list.get(idx).getText());
-    return rule == rootRule? null : rule;
+    return rule == rootRule ? null : rule;
   }
 
-  private static final Key<List<BnfExpression>> ORIGINAL_EXPRESSIONS = Key.create("ORIGINAL_EXPRESSIONS");
   private static BnfExpression combine(List<BnfExpression> list) {
     if (list.isEmpty()) return null;
     if (list.size() == 1) return list.get(0);

--- a/generator/src/org/intellij/grammar/generator/ExpressionHelper.java
+++ b/generator/src/org/intellij/grammar/generator/ExpressionHelper.java
@@ -33,7 +33,32 @@ import static org.intellij.grammar.psi.BnfAst.getChildExpressions;
 import static org.intellij.grammar.psi.BnfRules.getSuperRules;
 
 /**
- * @author gregsh
+ * Discovers and classifies expression-rule clusters in a BNF file.
+ * <p>
+ * An <i>expression rule</i> is a left-recursive rule whose alternatives form an
+ * operator-precedence table — atoms, prefix/postfix unaries, binary, and n-ary operators.
+ * Rather than rejecting the left recursion, the generator parses these clusters with the
+ * precedence-climbing scheme emitted by {@link ExpressionGeneratorHelper} (Java) and
+ * {@link KotlinParserGenerator#generateExpressionRoot} (Kotlin).
+ * <p>
+ * For each detected cluster this helper builds an {@link ExpressionInfo} containing:
+ * <ul>
+ *   <li>a priority ordering ({@link ExpressionInfo#priorityMap}) derived from the order in
+ *       which sub-rules are reachable from the root;</li>
+ *   <li>per-rule {@link OperatorInfo} entries telling the emitter the operator type
+ *       (ATOM/PREFIX/POSTFIX/BINARY/N_ARY), its operator subtree, and its argument rules;</li>
+ *   <li>private "priority groups" — private rules used purely to inject a priority level
+ *       without a corresponding generated method;</li>
+ *   <li>{@link ExpressionInfo#checkEmpty}, the set of operators that need a
+ *       {@code empty_element_parsed_guard_} to break out of an n-ary loop on empty matches.</li>
+ * </ul>
+ * <p>
+ * Detection is best-effort: ill-formed clusters are downgraded to {@code ATOM} with a warning,
+ * and rules that don't fit the expected shape (e.g. an n-ary operator without the required
+ * {@code rootRule (op rootRule)+} structure) are reported via {@link #addWarning}.
+ * <p>
+ * Cached per file via {@link #getCached(BnfFile)}; the cache is invalidated when the BNF file
+ * changes.
  */
 public class ExpressionHelper {
   private static final Key<CachedValue<ExpressionHelper>> EXPRESSION_HELPER_KEY = Key.create("EXPRESSION_HELPER_KEY");
@@ -46,6 +71,11 @@ public class ExpressionHelper {
   private final Map<BnfRule, ExpressionInfo> myExpressionMap = new HashMap<>();
   private final Map<BnfRule, BnfRule> myRootRulesMap = new HashMap<>();
 
+  /**
+   * Returns the cached {@link ExpressionHelper} for {@code file}, building one on first access.
+   * The cache is keyed off the file's modification stamp; the cached instance has no warning
+   * sink (warnings are only relevant during generation, where callers construct their own).
+   */
   public static ExpressionHelper getCached(@NotNull BnfFile file) {
     CachedValue<ExpressionHelper> value = file.getUserData(EXPRESSION_HELPER_KEY);
     if (value == null) {
@@ -55,19 +85,27 @@ public class ExpressionHelper {
     return value.getValue();
   }
 
-  public ExpressionHelper(BnfFile file, RuleGraphHelper ruleGraph, @Nullable Consumer<String> warningConsumer) {
+  public ExpressionHelper(@NotNull BnfFile file,
+                          @NotNull RuleGraphHelper ruleGraph,
+                          @Nullable Consumer<String> warningConsumer) {
     myFile = file;
     myRuleGraph = ruleGraph;
     myWarningConsumer = warningConsumer;
     buildExpressionRules();
   }
 
-  public void addWarning(String text) {
+  public void addWarning(@NotNull String text) {
     if (myWarningConsumer == null) return;
     myWarningConsumer.accept(text);
   }
 
-  public @Nullable ExpressionInfo getExpressionInfo(BnfRule rule) {
+  /**
+   * Returns the {@link ExpressionInfo} of the cluster that contains {@code rule}, or
+   * {@code null} if {@code rule} isn't part of an expression cluster. The root rule and any
+   * private rule always yield their cluster's info; non-private sub-rules only yield it when
+   * they have an entry in {@link ExpressionInfo#priorityMap}.
+   */
+  public @Nullable ExpressionInfo getExpressionInfo(@Nullable BnfRule rule) {
     BnfRule root = myRootRulesMap.get(rule);
     ExpressionInfo info = root == null ? null : myExpressionMap.get(root);
     if (info == null) return null;
@@ -75,6 +113,14 @@ public class ExpressionHelper {
     return info.priorityMap.containsKey(rule) ? info : null;
   }
 
+  /**
+   * Scans every non-private, non-fake rule and treats it as the root of an expression cluster
+   * if (a) the rule-graph reports no content rules for it (so it isn't a regular composite
+   * rule) and (b) its FIRST set contains a self-reference (the tell-tale sign of left
+   * recursion). For each such root, populates {@link #myExpressionMap} with priorities, an
+   * operator map (via {@link #buildOperatorMap}), and the {@code checkEmpty} set of operators
+   * whose entire body is optional and so need an empty-match guard at runtime.
+   */
   private void buildExpressionRules() {
     BnfFirstNextAnalyzer analyzer = BnfFirstNextAnalyzer.createAnalyzer(false);
     for (BnfRule rule : myFile.getRules()) {
@@ -105,6 +151,13 @@ public class ExpressionHelper {
     }
   }
 
+  /**
+   * Walks the cluster rooted at {@code rule}, descending only through the root and private
+   * priority groups, and assigns each visited rule either a priority entry or a private-group
+   * entry. Sub-rules outside {@code rulesCluster} (the extends-set of the root) that aren't
+   * private get a warning. Detects rules that participate in two clusters or are reached
+   * twice.
+   */
   private void addToPriorityMap(BnfRule rule, Collection<BnfRule> rulesCluster, ExpressionInfo info) {
     JBTreeTraverser<BnfRule> traverser = new JBTreeTraverser<>(
       o -> ObjectUtils.notNull(rule == o || BnfRules.isPrivate(o) ? myRuleGraph.getSubRules(o) : null, Collections.emptyList()));
@@ -135,6 +188,20 @@ public class ExpressionHelper {
     }
   }
 
+  /**
+   * Classifies {@code rule} as one of {@link OperatorType#ATOM}, {@code PREFIX},
+   * {@code POSTFIX}, {@code BINARY}, or {@code N_ARY} and stores the resulting
+   * {@link OperatorInfo} in {@code expressionInfo}. The classification is driven by the
+   * cardinality of {@code rootRule} inside this rule and the position(s) of the root reference
+   * among the child expressions:
+   * <ul>
+   *   <li>no occurrence → ATOM;</li>
+   *   <li>required (one occurrence): position 0 → POSTFIX, last → PREFIX;</li>
+   *   <li>at-least-one occurrence: two leading occurrences → BINARY; one occurrence followed by
+   *       {@code (op rootRule) +} → N_ARY.</li>
+   * </ul>
+   * Anything else triggers a warning and falls back to ATOM.
+   */
   private void buildOperatorMap(BnfRule rule, BnfRule rootRule, ExpressionInfo expressionInfo) {
     Map<PsiElement, RuleGraphHelper.Cardinality> ruleContent = myRuleGraph.getFor(rule);
     RuleGraphHelper.Cardinality cardinality = ruleContent.get(rootRule);
@@ -234,12 +301,19 @@ public class ExpressionHelper {
     expressionInfo.operatorMap.put(rule, info);
   }
 
+  /** Resolves the rule referenced at {@code list[idx]}, returning {@code null} when it's the root rule itself or {@code idx < 0}. */
   private @Nullable BnfRule substRule(List<BnfExpression> list, int idx, BnfRule rootRule) {
     if (idx < 0) return null;
     BnfRule rule = myFile.getRule(list.get(idx).getText());
     return rule == rootRule ? null : rule;
   }
 
+  /**
+   * Joins a slice of an operator's child expressions into a single synthetic
+   * {@link BnfExpression}, preserving the original list under {@link #ORIGINAL_EXPRESSIONS} so
+   * later analyses can recover it via {@link #getOriginalExpressions}. Returns the lone element
+   * verbatim for size-1 slices and {@code null} for empty slices.
+   */
   private static BnfExpression combine(List<BnfExpression> list) {
     if (list.isEmpty()) return null;
     if (list.size() == 1) return list.get(0);
@@ -250,12 +324,19 @@ public class ExpressionHelper {
     return result;
   }
 
-  public static @NotNull List<BnfExpression> getOriginalExpressions(BnfExpression expression) {
+  /** Recovers the original child slice that produced a {@link #combine}-synthesized expression, or returns {@code [expression]} for non-synthetic input. */
+  public static @NotNull List<BnfExpression> getOriginalExpressions(@NotNull BnfExpression expression) {
     List<BnfExpression> data = expression.getUserData(ORIGINAL_EXPRESSIONS);
     return data == null ? Collections.singletonList(expression) : data;
   }
 
-  public @NotNull RuleGraphHelper.Cardinality fixCardinality(BnfRule rule, PsiElement tree, RuleGraphHelper.Cardinality type) {
+  /**
+   * Adjusts a static cardinality to reflect runtime expression-parsing semantics: in an
+   * expression cluster, a {@code REQUIRED} child becomes {@code OPTIONAL} unless it sits in a
+   * pinned position (the first argument of a binary/n-ary/postfix operator, or anywhere inside
+   * the operator subtree). Atoms and rules outside any cluster are returned unchanged.
+   */
+  public @NotNull RuleGraphHelper.Cardinality fixCardinality(BnfRule rule, PsiElement tree, @NotNull RuleGraphHelper.Cardinality type) {
     if (type.optional()) return type;
     // in Expression parsing mode REQUIRED may go OPTIONAL
     ExpressionInfo info = getExpressionInfo(rule);
@@ -276,6 +357,11 @@ public class ExpressionHelper {
     }
   }
 
+  /**
+   * True if {@code target} lives inside {@code expression} either directly or via an original
+   * (pre-{@link #combine}) sub-expression. Drives the "is this child pinned by the operator?"
+   * check in {@link #fixCardinality}.
+   */
   private boolean isRealAncestor(BnfRule rule, BnfExpression expression, PsiElement target) {
     List<BnfExpression> list = getOriginalExpressions(expression);
     if (list.size() == 1 && PsiTreeUtil.isAncestor(list.get(0), target, false)) return true;
@@ -286,6 +372,11 @@ public class ExpressionHelper {
     return false;
   }
 
+  /**
+   * Returns the index in {@code childExpressions} (starting at {@code startIndex}) of the
+   * first reference to {@code rootRule} or any of its extends-rules / private priority groups,
+   * or {@code -1} if none is found. Used to locate the recursive operator argument(s).
+   */
   private int indexOf(BnfRule rootRule,
                       int startIndex,
                       List<BnfExpression> childExpressions,

--- a/generator/src/org/intellij/grammar/generator/FilePrinter.java
+++ b/generator/src/org/intellij/grammar/generator/FilePrinter.java
@@ -71,7 +71,7 @@ final class FilePrinter implements Closeable {
   }
 
   /**
-   * Sets the current offset level of this object to 0.
+   * Sets the current offset (indent) level of this object to 0.
    */
   public void resetOffset() {
     myOffset = 0;

--- a/generator/src/org/intellij/grammar/generator/Generator.java
+++ b/generator/src/org/intellij/grammar/generator/Generator.java
@@ -14,9 +14,11 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.JBIterable;
 import com.intellij.util.containers.MultiMap;
+import org.intellij.grammar.BnfPathsResolution;
 import org.intellij.grammar.KnownAttribute;
 import org.intellij.grammar.analysis.BnfFirstNextAnalyzer;
 import org.intellij.grammar.generator.NodeCalls.*;
+import org.intellij.grammar.java.JavaHelper;
 import org.intellij.grammar.psi.*;
 import org.intellij.grammar.psi.impl.GrammarUtil;
 import org.jetbrains.annotations.NotNull;
@@ -24,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.*;
 
 import static java.lang.String.format;
@@ -57,7 +60,7 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
    * The input BNF file to generate the parser from.
    */
   protected final @NotNull BnfFile myFile;
-  protected final @NotNull String myOutputPath;
+  protected final @NotNull BnfPathsResolution myPaths;
 
   /**
    * The package prefix to use for the generated parser.
@@ -70,6 +73,8 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
   protected final @NotNull GenOptions G;
   protected final @NotNull NameRenderer R;
   public final Names N;
+
+  protected final JavaHelper myJavaHelper;
 
   private final @NotNull String myOutputFileExtension;
   protected final @NotNull OutputOpener myOpener;
@@ -117,22 +122,24 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
 
   protected Generator(@NotNull BnfFile psiFile,
                       @NotNull String sourcePath,
-                      @NotNull String outputPath,
                       @NotNull String packagePrefix,
                       @NotNull String outputFileExtension,
                       @NotNull OutputOpener outputOpener,
-                      @NotNull NameRenderer nameRenderer) {
+                      @NotNull NameRenderer nameRenderer,
+                      @NotNull BnfPathsResolution paths) {
     myFile = psiFile;
 
     G = new GenOptions(psiFile);
     N = G.names;
     R = nameRenderer;
     mySourcePath = sourcePath;
-    myOutputPath = outputPath;
+    myPaths = paths;
     myPackagePrefix = packagePrefix;
     myOutputFileExtension = outputFileExtension;
     myOpener = outputOpener;
 
+    myJavaHelper = JavaHelper.getJavaHelper(myFile);
+    
     List<BnfRule> rules = psiFile.getRules();
     BnfRule rootRule = rules.isEmpty() ? null : rules.get(0);
     myGrammarRoot = rootRule == null ? null : rootRule.getName();
@@ -186,13 +193,18 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
   }
 
   /**
-   * Resolves {@code className} to a file under {@link #myOutputPath} (stripping {@link #myPackagePrefix})
-   * and installs a fresh {@link FilePrinter} as the current output sink.
+   * Opens an output file for {@code className} under {@code basePath} (with {@link #myPackagePrefix}
+   * stripped from the FQN), and installs a fresh {@link FilePrinter} as the current output sink.
+   * Callers pass the resolved path attribute that owns the artifact, e.g.
+   * {@code myPaths.pathString(KnownAttribute.PARSER_OUTPUT_PATH)} —
+   * {@link BnfPathsResolution#pathString} throws if the attribute has no value, so a missing
+   * directory surfaces at the call site rather than here.
    */
-  protected void openOutput(String className) throws IOException {
+  protected void openOutput(@NotNull String className, @NotNull String basePath) throws IOException {
     String classNameAdjusted = myPackagePrefix.isEmpty() ? className : StringUtil.trimStart(className, myPackagePrefix + ".");
-    File file = new File(myOutputPath, classNameAdjusted.replace('.', File.separatorChar) + "." + myOutputFileExtension);
-    myPrinter = new FilePrinter(myOpener.openOutput(className, file, myFile));
+    File file = new File(basePath, classNameAdjusted.replace('.', File.separatorChar) + "." + myOutputFileExtension);
+    PrintWriter output = myOpener.openOutput(className, file, myFile);
+    myPrinter = new FilePrinter(output);
   }
 
   protected void closeOutput() {

--- a/generator/src/org/intellij/grammar/generator/Generator.java
+++ b/generator/src/org/intellij/grammar/generator/Generator.java
@@ -35,6 +35,21 @@ import static org.intellij.grammar.psi.BnfAttributes.getAttribute;
 import static org.intellij.grammar.psi.BnfAttributes.getRootAttribute;
 import static org.intellij.grammar.psi.BnfRules.getSynonymTargetOrSelf;
 
+/**
+ * Sealed base for the BNF-to-source code emitters. A {@code Generator} consumes a parsed
+ * {@link BnfFile} together with its {@link GenOptions} and produces a parser (and, depending on
+ * the target, PSI / element-type holders) by writing source files through {@link FilePrinter}
+ * and {@link OutputOpener}.
+ * <p>
+ * This class owns target-agnostic concerns: locating rules, computing element types, building
+ * the rule graph and FIRST/NEXT analysis, tracking lambdas/meta-method fields shared across
+ * generated parser methods, and gathering token sets emitted for token-choice expressions.
+ * Anything that depends on the target language's syntax (method generation, node calls, recovery
+ * snippets) is left abstract for subclasses to implement.
+ * <p>
+ * Subclasses are sealed to {@link JavaParserGenerator} and {@link KotlinParserGenerator}.
+ * Instances are single-use: state accumulated during one {@link #generate()} call is not reset.
+ */
 public sealed abstract class Generator permits JavaParserGenerator, KotlinParserGenerator {
   private static final Logger LOG = Logger.getInstance(Generator.class);
 
@@ -127,10 +142,19 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     myFirstNextAnalyzer = BnfFirstNextAnalyzer.createAnalyzer(true);
   }
 
+  /**
+   * Runs the full generation pipeline for this target: emits the parser and any auxiliary
+   * artifacts (element-type holders, PSI interfaces/impls, visitor) the target supports.
+   */
   public abstract void generate() throws IOException;
 
+  /**
+   * Emits only the parser source(s). One file is produced per distinct
+   * {@link KnownAttribute#PARSER_CLASS} value across the grammar's rules.
+   */
   public abstract void generateParser() throws IOException;
 
+  /** Emits the {@link KnownAttribute#CLASS_HEADER classHeader} preamble for {@code className}, if one is configured. */
   protected final void generateFileHeader(String className) {
     String header = getRootAttribute(myFile, KnownAttribute.CLASS_HEADER, className);
     String text = StringUtil.isEmpty(header) ? "" : getStringOrFile(header);
@@ -161,6 +185,10 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
              "// " + classHeader;
   }
 
+  /**
+   * Resolves {@code className} to a file under {@link #myOutputPath} (stripping {@link #myPackagePrefix})
+   * and installs a fresh {@link FilePrinter} as the current output sink.
+   */
   protected void openOutput(String className) throws IOException {
     String classNameAdjusted = myPackagePrefix.isEmpty() ? className : StringUtil.trimStart(className, myPackagePrefix + ".");
     File file = new File(myOutputPath, classNameAdjusted.replace('.', File.separatorChar) + "." + myOutputFileExtension);
@@ -187,13 +215,19 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     return myShortener.shorten(s);
   }
 
+  /** Sets indent in the printer to zero. */
   protected void resetOffset() {
     myPrinter.resetOffset();
   }
 
   protected enum TypeKind {CLASS, INTERFACE, ABSTRACT_CLASS}
 
-  protected @NotNull Set<String> collectClasses(Set<String> imports, String packageName) {
+  /**
+   * Returns the short names of generated PSI interface/impl classes that are reachable from
+   * {@code packageName} via {@code imports} (own package or wildcard imports). The result feeds
+   * the name shortener so that those generated classes are not accidentally short-named to clash.
+   */
+  protected @NotNull Set<String> collectClasses(@NotNull Set<String> imports, @NotNull String packageName) {
     Set<String> includedPackages = JBIterable.from(imports)
       .filter(o -> !o.startsWith("static") && o.endsWith(".*"))
       .map(o -> StringUtil.trimEnd(o, ".*"))
@@ -206,6 +240,12 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     return includedClasses;
   }
 
+  /**
+   * Returns the constant name a {@code Parser} lambda for {@code nodeCall} should be referenced
+   * by, registering its body in {@link #myParserLambdas} on first request. If the call doesn't
+   * just delegate to {@code nextName(...)}, that {@code nextName} is added to
+   * {@link #myInlinedChildNodes} so its child generation is skipped (the lambda inlines it).
+   */
   @NotNull String getParserLambdaRef(@NotNull NodeCall nodeCall, @NotNull String nextName) {
     String constantName = CommonRendererUtils.getWrapperParserConstantName(nextName);
     String targetClass = myRenderedLambdas.get(constantName);
@@ -226,6 +266,11 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     return Objects.requireNonNull(myRuleInfos.get(rule.getName()));
   }
 
+  /**
+   * Marks rules whose generated PSI impl should be {@code abstract}: rules without modifiers,
+   * recovery, or hooks, that aren't reused as another rule's element type, aren't the grammar
+   * root, and the rule graph reports as collapsible with no incoming references.
+   */
   protected void calcAbstractRules() {
     final var reusedRules = new HashSet<String>();
     for (BnfRule rule : myFile.getRules()) {
@@ -255,11 +300,22 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     return generateNodeCall(rule, node, nextName, null);
   }
 
+  /**
+   * Builds the {@link NodeCall} that invokes the parser for {@code node} from inside {@code rule}.
+   * For tokens this is a {@code consumeToken}; for sub-rules, a method call to the generated rule
+   * function; for external/meta references, the appropriate external/meta call. {@code nextName}
+   * is the function name to use when the call has to be inlined as a nested helper.
+   */
   abstract NodeCall generateNodeCall(@NotNull BnfRule rule,
                                      @Nullable BnfExpression node,
                                      @NotNull String nextName,
                                      @Nullable ConsumeType forcedConsumeType);
 
+  /**
+   * If {@code children} is a homogeneous list of at least two tokens, registers a token-set
+   * constant for them in {@link #myChoiceTokenSets} and returns a {@code consumeTokenFast(set)}
+   * call. Returns {@code null} when no such optimization applies.
+   */
   @Nullable NodeCall generateTokenChoiceCall(@NotNull List<BnfExpression> children,
                                              @NotNull ConsumeType consumeType,
                                              @NotNull String funcName) {
@@ -279,6 +335,12 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     return instantiateTokenChoiceCall(consumeType, tokenSetName);
   }
 
+  /**
+   * Folds a run of consecutive token children starting at {@code startIndex} into a single
+   * {@code consumeTokens}/{@code parseTokens} call when at least two tokens fit. {@code skip}
+   * is set to the number of children to bypass in the caller's loop, and pin information is
+   * propagated through {@code pinMatcher}.
+   */
   abstract @NotNull NodeCall generateTokenSequenceCall(@NotNull List<BnfExpression> children,
                                                        int startIndex,
                                                        PinMatcher pinMatcher,
@@ -288,10 +350,21 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
                                                        boolean rollbackOnFail,
                                                        ConsumeType consumeType);
 
+  /** Builds the target-specific {@code consumeToken(set)} call that backs {@link #generateTokenChoiceCall}. */
   abstract @NotNull NodeCall instantiateTokenChoiceCall(@NotNull ConsumeType consumeType, @NotNull String tokenSetName);
 
+  /**
+   * Emits an early-exit FIRST-set check for {@code rule}: when the next token can't possibly
+   * begin {@code rule}, return {@code false} immediately. Returns the (possibly cleared)
+   * {@code frameName} to use in the section header when the FIRST set was emitted inline.
+   */
   protected abstract @Nullable String generateFirstCheck(@NotNull BnfRule rule, @Nullable String frameName, boolean skipIfOne);
 
+  /**
+   * Maps an entry of a FIRST set (token name, quoted text, or rule reference marker) to the
+   * generated element-type constant. Returns {@code null} for non-token entries (rules,
+   * external markers like {@code <<…>>}) that have no concrete element type.
+   */
   protected @Nullable String firstToElementType(String first) {
     if (first.startsWith("#") || first.startsWith("-") || first.startsWith("<<")) return null;
     String value = GrammarUtil.unquote(first);
@@ -316,6 +389,12 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     }
   }
 
+  /**
+   * Recursively emits helper parser methods for {@code child} (and, for external expressions,
+   * for each non-atomic argument). Atomic and pure-token-sequence children are skipped because
+   * their calls are inlined; children already marked as inlined via {@link #myInlinedChildNodes}
+   * are also skipped.
+   */
   void generateNodeChild(@NotNull BnfRule rule,
                          @NotNull BnfExpression child,
                          @NotNull String funcName,
@@ -349,6 +428,13 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     // else do not generate
   }
 
+  /**
+   * Emits a call to an external rule / meta rule. {@code expressions} holds the call form
+   * {@code [methodName, arg1, arg2, ...]}; if it targets an external grammar rule, that rule's
+   * own argument list is merged in. Each argument is rendered via {@link #generateWrappedNodeCall}.
+   * Returns a {@link MetaMethodCall} when the target is a meta rule, otherwise a
+   * {@link MethodCallWithArguments}.
+   */
   @NotNull NodeCall generateExternalCall(@NotNull BnfRule rule,
                                          @NotNull List<BnfExpression> expressions,
                                          @NotNull String nextName,
@@ -431,11 +517,18 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     return !parserClass.equals(ruleInfo(rule).parserClass);
   }
 
+  /** Formats a meta-rule parameter name (the {@code <<x>>} placeholder text) to its identifier in generated code. */
   @NotNull String formatMetaParamName(@NotNull String s) {
     String argName = s.trim();
     return N.metaParamPrefix + (N.metaParamPrefix.isEmpty() || "_".equals(N.metaParamPrefix) ? argName : StringUtil.capitalize(argName));
   }
 
+  /**
+   * Wraps the call for {@code nested} as a {@link NodeArgument} suitable for passing to another
+   * generated parser function. Plain method calls become method references, meta-method calls
+   * that don't reference meta-parameters are cached in static fields, and everything else is
+   * rendered as a parser-lambda reference via {@link #getParserLambdaRef}.
+   */
   @NotNull
   NodeArgument generateWrappedNodeCall(@NotNull BnfRule rule, @Nullable BnfExpression nested, @NotNull String nextName) {
     NodeCall nodeCall = generateNodeCall(rule, nested, nextName);
@@ -456,6 +549,7 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     }
   }
 
+  /** Caches a parameter-free meta-method {@code call} as a static {@code Parser} field and returns its name. */
   private @NotNull String getMetaMethodFieldRef(@NotNull String call, @NotNull String nextName) {
     String fieldName = CommonRendererUtils.getWrapperParserConstantName(nextName);
     myMetaMethodFields.putIfAbsent(fieldName, call);
@@ -471,6 +565,11 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
   }
 
   /**
+   * Builds the {@code #auto} recovery predicate for {@code rule}: a check that the current
+   * token is none of the FIRST-of-NEXT element types. Registers it as a parser lambda and
+   * returns its constant name. Emits a warning and produces an empty token list when the NEXT
+   * set contains references that don't reduce to concrete element types.
+   *
    * @noinspection StringEquality
    */
   protected String generateAutoRecoverCall(BnfRule rule) {
@@ -501,6 +600,7 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     return constantName;
   }
 
+  /** Renders the body of the auto-recovery lambda — a {@code !nextTokenIsFast(...)} expression in the target language. */
   abstract StringBuilder generateAutoRecoveryCall(List<String> tokenTypes);
 
   protected final @NotNull String getElementType(String token) {
@@ -511,6 +611,11 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     return CommonRendererUtils.getElementType(rule, G.generateElementCase);
   }
 
+  /**
+   * From the rule {@code extends} graph, builds the {@code EXTENDS_SETS_} groups: the element-type
+   * sets the runtime uses to answer "is X-as-element-type also a Y?" Skips fake/synonym rules
+   * with no own element type and drops smaller sets fully contained in larger ones.
+   */
   protected @NotNull List<Set<String>> buildExtendsSet(@NotNull MultiMap<BnfRule, BnfRule> map) {
     if (map.isEmpty()) return Collections.emptyList();
     List<Set<String>> result = new ArrayList<>();
@@ -540,6 +645,7 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     return result;
   }
 
+  /** Reports a generator warning — to {@code stdout} under tests, otherwise as an IDE notification. */
   public void addWarning(String text) {
     if (ApplicationManager.getApplication().isUnitTestMode()) {
       //noinspection UseOfSystemOutOrSystemErr

--- a/generator/src/org/intellij/grammar/generator/Generator.java
+++ b/generator/src/org/intellij/grammar/generator/Generator.java
@@ -19,6 +19,7 @@ import org.intellij.grammar.KnownAttribute;
 import org.intellij.grammar.analysis.BnfFirstNextAnalyzer;
 import org.intellij.grammar.generator.NodeCalls.*;
 import org.intellij.grammar.java.JavaHelper;
+import org.intellij.grammar.java.PsiHelperFactory;
 import org.intellij.grammar.psi.*;
 import org.intellij.grammar.psi.impl.GrammarUtil;
 import org.jetbrains.annotations.NotNull;
@@ -75,6 +76,7 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
   public final Names N;
 
   protected final JavaHelper myJavaHelper;
+  private final @NotNull Map<KnownAttribute<?>, JavaHelper> myScopedHelpers = new HashMap<>();
 
   private final @NotNull String myOutputFileExtension;
   protected final @NotNull OutputOpener myOpener;
@@ -209,6 +211,23 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
 
   protected void closeOutput() {
     myPrinter.close();
+  }
+
+  /**
+   * Returns a {@link JavaHelper} whose class-lookup scope is narrowed by the {@code *InputPath}
+   * sibling of {@code attribute}, anchored at the BNF psi node that declares it. When the
+   * attribute is not declared in the grammar, falls back to the rule (or file) — in which case
+   * only the global {@code inputPath} default applies.
+   */
+  protected final @NotNull JavaHelper helperFor(@Nullable BnfRule rule, @NotNull KnownAttribute<?> attribute) {
+    // BnfPaths.referencePath consults grammar-level (root) attributes; per-rule scoping is not
+    // supported today. The rule parameter is retained for callers' clarity and future expansion.
+    PsiHelperFactory factory = myFile.getProject().getService(PsiHelperFactory.class);
+    if (factory == null) {
+      // Headless / CLI: AsmHelper has no scope concept; one shared instance is sufficient.
+      return myJavaHelper;
+    }
+    return myScopedHelpers.computeIfAbsent(attribute, attr -> factory.getInstance(myPaths, attr));
   }
 
   public void out(String s, Object... args) {

--- a/generator/src/org/intellij/grammar/generator/JavaParserGenerator.java
+++ b/generator/src/org/intellij/grammar/generator/JavaParserGenerator.java
@@ -18,6 +18,7 @@ import com.intellij.util.Function;
 import com.intellij.util.ObjectUtils;
 import com.intellij.util.SmartList;
 import com.intellij.util.containers.*;
+import org.intellij.grammar.BnfPathsResolution;
 import org.intellij.grammar.KnownAttribute;
 import org.intellij.grammar.analysis.BnfFirstNextAnalyzer;
 import org.intellij.grammar.generator.NodeCalls.*;
@@ -96,14 +97,13 @@ public final class JavaParserGenerator extends Generator {
 
   private final ExpressionHelper myExpressionHelper;
   private final RuleMethodsHelper myRulesMethodsHelper;
-  private final JavaHelper myJavaHelper;
 
   public JavaParserGenerator(@NotNull BnfFile psiFile,
                              @NotNull String sourcePath,
-                             @NotNull String outputPath,
                              @NotNull String packagePrefix,
-                             @NotNull OutputOpener outputOpener) {
-    super(psiFile, sourcePath, outputPath, packagePrefix, "java", outputOpener, new JavaNameRenderer());
+                             @NotNull OutputOpener outputOpener,
+                             @NotNull BnfPathsResolution paths) {
+    super(psiFile, sourcePath, packagePrefix, "java", outputOpener, new JavaNameRenderer(), paths);
 
     myPsiInterfaceFormat = NameFormat.forPsiClass(myFile);
     myImplClassFormat = NameFormat.forPsiImplClass(myFile);
@@ -121,7 +121,6 @@ public final class JavaParserGenerator extends Generator {
 
     myExpressionHelper = new ExpressionHelper(myFile, myGraphHelper, this::addWarning);
     myRulesMethodsHelper = new RuleMethodsHelper(myGraphHelper, myExpressionHelper, mySimpleTokens, G);
-    myJavaHelper = JavaHelper.getJavaHelper(myFile);
 
     List<BnfRule> rules = psiFile.getRules();
     BnfRule rootRule = rules.isEmpty() ? null : rules.get(0);
@@ -264,7 +263,7 @@ public final class JavaParserGenerator extends Generator {
       calcRealSuperClasses(sortedPsiRules);
     }
     if (myGrammarRoot != null && (G.generateTokenTypes || G.generateElementTypes || G.generatePsi && G.generatePsiFactory)) {
-      openOutput(myPsiElementTypeHolderClass);
+      openOutput(myPsiElementTypeHolderClass, myPaths.pathString(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
       try {
         generateElementTypesHolder(myPsiElementTypeHolderClass,
                                    sortedCompositeTypes,
@@ -277,7 +276,7 @@ public final class JavaParserGenerator extends Generator {
     }
     if (G.parserApi == GenOptions.ParserApi.Syntax) {
       var converterClass = getRootAttribute(myFile, KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_CLASS);
-      openOutput(converterClass);
+      openOutput(converterClass, myPaths.pathString(KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH));
       try {
         generateElementTypesConverter(converterClass,
                                       myParserTypeHolderClass,
@@ -294,7 +293,7 @@ public final class JavaParserGenerator extends Generator {
   }
 
   /** Warns when {@code className} is configured but not resolvable on the classpath. */
-  private void checkClassAvailability(@Nullable String className) {
+  private void checkClassAvailability(@Nullable String className, @NotNull KnownAttribute<?> attribute) {
     if (StringUtil.isEmpty(className)) return;
     if (myJavaHelper.findClass(className) == null) {
       String tail = StringUtil.isEmpty("PSI method signatures will not be detected") ? "" : " (PSI method signatures will not be detected)";
@@ -440,7 +439,7 @@ public final class JavaParserGenerator extends Generator {
   public void generateParser() throws IOException {
     Map<String, Set<RuleInfo>> classified = ContainerUtil.classify(myRuleInfos.values().iterator(), o -> o.parserClass);
     for (String className : ContainerUtil.sorted(classified.keySet())) {
-      openOutput(className);
+      openOutput(className, myPaths.pathString(KnownAttribute.PARSER_OUTPUT_PATH));
       try {
         generateParser(className, map(classified.get(className), it -> it.name));
       }
@@ -1370,11 +1369,12 @@ public final class JavaParserGenerator extends Generator {
   /*PSI******************************************************************/
   /** Emits the PSI interface and impl for each rule, plus the visitor when one is configured. */
   private void generatePsi(Map<String, BnfRule> sortedPsiRules) throws IOException {
-    checkClassAvailability(myPsiImplUtilClass);
+    checkClassAvailability(myPsiImplUtilClass, KnownAttribute.PSI_IMPL_UTIL_CLASS);
     myRulesMethodsHelper.buildMaps(sortedPsiRules.values());
+    String psiOutput = myPaths.pathString(KnownAttribute.PSI_OUTPUT_PATH);
     for (BnfRule rule : sortedPsiRules.values()) {
       RuleInfo info = ruleInfo(rule);
-      openOutput(info.intfClass);
+      openOutput(info.intfClass, psiOutput);
       try {
         generatePsiIntf(rule, info);
       }
@@ -1384,7 +1384,7 @@ public final class JavaParserGenerator extends Generator {
     }
     for (BnfRule rule : sortedPsiRules.values()) {
       RuleInfo info = ruleInfo(rule);
-      openOutput(info.implClass);
+      openOutput(info.implClass, psiOutput);
       try {
         generatePsiImpl(rule, info);
       }
@@ -1393,7 +1393,7 @@ public final class JavaParserGenerator extends Generator {
       }
     }
     if (myVisitorClassName != null && myGrammarRoot != null) {
-      openOutput(myVisitorClassName);
+      openOutput(myVisitorClassName, psiOutput);
       try {
         generateVisitor(myVisitorClassName, sortedPsiRules);
       }

--- a/generator/src/org/intellij/grammar/generator/JavaParserGenerator.java
+++ b/generator/src/org/intellij/grammar/generator/JavaParserGenerator.java
@@ -172,9 +172,10 @@ public final class JavaParserGenerator extends Generator {
                               ruleInfo(topSuper).intfClass;
       String implSuper = StringUtil.notNullize(info.mixin, superRuleClass);
       String implSuperRaw = getRawClassName(implSuper);
+      JavaHelper hierarchyHelper = helperFor(rule, KnownAttribute.MIXIN);
       String stubName =
         StringUtil.isNotEmpty(stubClass) ? stubClass :
-        implSuper.indexOf("<") < implSuper.indexOf(">") && !myJavaHelper.findClassMethods(implSuperRaw, JavaHelper.MethodType.INSTANCE, "getParentByStub", 0).isEmpty() ?
+        implSuper.indexOf("<") < implSuper.indexOf(">") && !hierarchyHelper.findClassMethods(implSuperRaw, JavaHelper.MethodType.INSTANCE, "getParentByStub", 0).isEmpty() ?
         implSuper.substring(implSuper.indexOf("<") + 1, implSuper.indexOf(">")) : null;
       if (StringUtil.isNotEmpty(stubName)) {
         info.realStubClass = stubClass;
@@ -211,9 +212,10 @@ public final class JavaParserGenerator extends Generator {
         superRuleClass.contains("?") ? superRuleClass.replaceAll("\\?", stubName) : superRuleClass;
       // mixin attribute overrides "extends":
       info.realSuperClass = StringUtil.notNullize(info.mixin, adjustedSuperRuleClass);
+      JavaHelper hierarchyHelper = helperFor(rule, KnownAttribute.MIXIN);
       info.mixedAST = topInfo != null ? topInfo.mixedAST : JBIterable.of(superRuleClass, info.realSuperClass)
         .map(JavaNames::getRawClassName)
-        .flatMap(s -> JBTreeTraverser.<String>from(o -> JBIterable.of(myJavaHelper.getSuperClassName(o))).withRoot(s).unique())
+        .flatMap(s -> JBTreeTraverser.<String>from(o -> JBIterable.of(hierarchyHelper.getSuperClassName(o))).withRoot(s).unique())
         .find(JavaBnfConstants.COMPOSITE_PSI_ELEMENT_CLASS::equals) != null;
     }
   }
@@ -295,7 +297,7 @@ public final class JavaParserGenerator extends Generator {
   /** Warns when {@code className} is configured but not resolvable on the classpath. */
   private void checkClassAvailability(@Nullable String className, @NotNull KnownAttribute<?> attribute) {
     if (StringUtil.isEmpty(className)) return;
-    if (myJavaHelper.findClass(className) == null) {
+    if (helperFor(null, attribute).findClass(className) == null) {
       String tail = StringUtil.isEmpty("PSI method signatures will not be detected") ? "" : " (PSI method signatures will not be detected)";
       addWarning(className + " class not found" + tail);
     }
@@ -320,10 +322,11 @@ public final class JavaParserGenerator extends Generator {
       // ensure only public supers are exposed, replace non-public with default super-intf for simplicity
       Map<String, String> replacements = new HashMap<>();
       Set<String> visited = new HashSet<>();
+      JavaHelper implementsHelper = helperFor(null, KnownAttribute.IMPLEMENTS);
       for (String s : supers.values()) {
         if (!visited.add(s)) continue;
-        NavigatablePsiElement aClass = myJavaHelper.findClass(s);
-        if (aClass != null && !myJavaHelper.isPublic(aClass)) {
+        NavigatablePsiElement aClass = implementsHelper.findClass(s);
+        if (aClass != null && !implementsHelper.isPublic(aClass)) {
           replacements.put(s, superIntf);
         }
       }
@@ -1470,6 +1473,7 @@ public final class JavaParserGenerator extends Generator {
     List<NavigatablePsiElement> constructors = Collections.emptyList();
     BnfRule topSuperRule = null;
     String topSuperClass = null;
+    JavaHelper hierarchyHelper = helperFor(rule, KnownAttribute.MIXIN);
     for (BnfRule next = rule; next != null && next != topSuperRule; ) {
       if (!visited.add(next)) {
         addWarning(rule.getName() + " employs cyclic inheritance");
@@ -1481,7 +1485,7 @@ public final class JavaParserGenerator extends Generator {
       next = getEffectiveSuperRule(myFile, next);
       if (next != null && next != topSuperRule && getAttribute(topSuperRule, KnownAttribute.MIXIN) == null) continue;
       topSuperClass = getRawClassName(superClass);
-      constructors = myJavaHelper.findClassMethods(topSuperClass, JavaHelper.MethodType.CONSTRUCTOR, "*", -1);
+      constructors = hierarchyHelper.findClassMethods(topSuperClass, JavaHelper.MethodType.CONSTRUCTOR, "*", -1);
       if (!constructors.isEmpty()) break;
     }
     if (!G.generateFQN) {
@@ -1539,8 +1543,8 @@ public final class JavaParserGenerator extends Generator {
       boolean addOverride = topSuperRule != rule && info.mixin == null;
       if (!addOverride && topSuperClass != null) {
         main:
-        for (String curClass = topSuperClass; curClass != null; curClass = myJavaHelper.getSuperClassName(curClass)) {
-          for (NavigatablePsiElement m : myJavaHelper.findClassMethods(
+        for (String curClass = topSuperClass; curClass != null; curClass = hierarchyHelper.getSuperClassName(curClass)) {
+          for (NavigatablePsiElement m : hierarchyHelper.findClassMethods(
             curClass, JavaHelper.MethodType.INSTANCE, "accept", 1, myVisitorClassName)) {
             String paramType = myJavaHelper.getMethodTypes(m).get(1);
             if (getRawClassName(paramType).endsWith(StringUtil.getShortName(myVisitorClassName))) {
@@ -1586,13 +1590,13 @@ public final class JavaParserGenerator extends Generator {
           if (intf) {
             String mixinClass = getAttribute(rule, KnownAttribute.MIXIN);
             List<NavigatablePsiElement> methods =
-              myJavaHelper.findClassMethods(mixinClass, JavaHelper.MethodType.INSTANCE, methodInfo.name, -1);
+              helperFor(rule, KnownAttribute.MIXIN).findClassMethods(mixinClass, JavaHelper.MethodType.INSTANCE, methodInfo.name, -1);
             for (NavigatablePsiElement method : methods) {
               generateUtilMethod(methodInfo.name, method, true, false, visited);
               found = true;
             }
           }
-          List<NavigatablePsiElement> methods = myJavaHelper.findRuleImplMethods(myPsiImplUtilClass, methodInfo.name, rule);
+          List<NavigatablePsiElement> methods = helperFor(null, KnownAttribute.PSI_IMPL_UTIL_CLASS).findRuleImplMethods(myPsiImplUtilClass, methodInfo.name, rule);
           for (NavigatablePsiElement method : methods) {
             generateUtilMethod(methodInfo.name, method, intf, true, visited);
             found = true;
@@ -1642,8 +1646,8 @@ public final class JavaParserGenerator extends Generator {
       if (methodInfo.type != RuleMethodsHelper.MethodType.MIXIN) continue;
 
       List<NavigatablePsiElement> mixinMethods =
-        myJavaHelper.findClassMethods(mixinClass, JavaHelper.MethodType.INSTANCE, methodInfo.name, -1);
-      List<NavigatablePsiElement> implMethods = myJavaHelper.findRuleImplMethods(myPsiImplUtilClass, methodInfo.name, rule);
+        helperFor(rule, KnownAttribute.MIXIN).findClassMethods(mixinClass, JavaHelper.MethodType.INSTANCE, methodInfo.name, -1);
+      List<NavigatablePsiElement> implMethods = helperFor(null, KnownAttribute.PSI_IMPL_UTIL_CLASS).findRuleImplMethods(myPsiImplUtilClass, methodInfo.name, rule);
 
       collectMethodTypesToImport(mixinMethods, false, result);
       collectMethodTypesToImport(implMethods, true, result);

--- a/generator/src/org/intellij/grammar/generator/JavaParserGenerator.java
+++ b/generator/src/org/intellij/grammar/generator/JavaParserGenerator.java
@@ -61,8 +61,19 @@ import static org.intellij.grammar.psi.BnfTypes.*;
 
 
 /**
- * @author gregory
- * Date 16.07.11 10:41
+ * {@link Generator} implementation that emits Java sources: the parser, the element-type holder,
+ * PSI interfaces and impls, and (when enabled) a visitor.
+ * <p>
+ * {@link #generate()} runs the full pipeline; {@link #generatePsiOnly()} is invoked by
+ * {@link KotlinParserGenerator} so the Kotlin parser can reuse Java PSI emission while owning
+ * parser generation itself. {@link #replaceSimpleTokes(Map)} exists for the same flow: simple
+ * tokens discovered during Kotlin parser generation must be propagated here before PSI emission
+ * so that element types line up.
+ * <p>
+ * Beyond plain emission this class drives Java-specific shape decisions: stub class resolution
+ * via {@link JavaHelper}, real super-class chains for PSI impls (taking {@code mixin} and
+ * stub-aware {@code extends} into account), expression-rule handling through
+ * {@link ExpressionHelper}, and PSI method synthesis through {@link RuleMethodsHelper}.
  */
 public final class JavaParserGenerator extends Generator {
   public static final Logger LOG = Logger.getInstance(JavaParserGenerator.class);
@@ -134,6 +145,7 @@ public final class JavaParserGenerator extends Generator {
     calcAbstractRules();
   }
 
+  /** Marks rules that are reused as another rule's {@code elementType}, so they keep an element-type entry even when {@code fake}. */
   private void calcFakeRulesWithType() {
     for (BnfRule rule : myFile.getRules()) {
       BnfRule r = myFile.getRule(getAttribute(rule, KnownAttribute.ELEMENT_TYPE));
@@ -142,6 +154,11 @@ public final class JavaParserGenerator extends Generator {
     }
   }
 
+  /**
+   * Resolves each rule's effective stub class: an explicit {@code stubClass}, a stub inherited
+   * from the effective super-rule, or the type argument of a stub-aware base class on the
+   * {@code mixin}/{@code extends} chain. Stores the result in {@link RuleInfo#realStubClass}.
+   */
   private void calcRulesStubNames() {
     for (BnfRule rule : myFile.getRules()) {
       RuleInfo info = ruleInfo(rule);
@@ -166,6 +183,12 @@ public final class JavaParserGenerator extends Generator {
     }
   }
 
+  /**
+   * Computes each PSI rule's {@code realSuperClass} (used for the {@code extends} clause of the
+   * generated impl) and {@code mixedAST} flag, walking the rule super-chain in post-order so a
+   * super's resolved values are visible to its descendants. Honors {@code mixin} overrides and
+   * substitutes the resolved stub type into stub-parameterized base classes.
+   */
   private void calcRealSuperClasses(Map<String, BnfRule> sortedPsiRules) {
     Map<BnfRule, BnfRule> supers = new HashMap<>();
     for (BnfRule rule : sortedPsiRules.values()) {
@@ -204,13 +227,23 @@ public final class JavaParserGenerator extends Generator {
     generatePsiOnly();
   }
   
-  //Because some of the simple tokens are added during parser generation, 
-  // we use this function to pass missing tokens from KotlinParserGenerator to JavaParserGenerator
+  /**
+   * Replaces this generator's simple-token map with {@code simpleTypes}.
+   * <p>
+   * Called by {@link KotlinParserGenerator#generate()} so that simple tokens it discovered during
+   * parser generation are visible here before {@link #generatePsiOnly()} emits the element-type
+   * holder and PSI.
+   */
   public void replaceSimpleTokes(Map<String, String> simpleTypes) {
     mySimpleTokens.clear();
     mySimpleTokens.putAll(simpleTypes);
   }
   
+  /**
+   * Emits everything except the parser: the element-type holder, an optional Syntax-API element
+   * type converter, and (when {@link GenOptions#generatePsi}) PSI interfaces, impls, and visitor.
+   * Invoked directly by {@link KotlinParserGenerator}, which owns its own parser generation.
+   */
   public void generatePsiOnly() throws IOException {
     Map<String, BnfRule> sortedCompositeTypes = new TreeMap<>();
     Map<String, BnfRule> sortedPsiRules = new TreeMap<>();
@@ -260,6 +293,7 @@ public final class JavaParserGenerator extends Generator {
     }
   }
 
+  /** Warns when {@code className} is configured but not resolvable on the classpath. */
   private void checkClassAvailability(@Nullable String className) {
     if (StringUtil.isEmpty(className)) return;
     if (myJavaHelper.findClass(className) == null) {
@@ -268,6 +302,13 @@ public final class JavaParserGenerator extends Generator {
     }
   }
 
+  /**
+   * Emits the PSI visitor class. Each rule gets a {@code visit<Rule>} method that delegates to
+   * its first declared super-interface; remaining supers are listed as commented-out alternatives.
+   * Non-public super-interfaces are replaced with the configured base interface. When
+   * {@link GenOptions#visitorValue} is set, methods carry that type parameter and {@code return}
+   * the delegate result.
+   */
   private void generateVisitor(String psiClass, Map<String, BnfRule> sortedRules) {
     String superIntf = ObjectUtils.notNull(ContainerUtil.getFirstItem(getRootAttribute(myFile, KnownAttribute.IMPLEMENTS)),
                                            KnownAttribute.IMPLEMENTS.getDefaultValue().get(0)).second;
@@ -348,6 +389,11 @@ public final class JavaParserGenerator extends Generator {
     out("}");
   }
 
+  /**
+   * Emits the file header, package declaration, imports, optional annotations and the class/
+   * interface declaration line for {@code className}. Installs a fresh {@link JavaNameShortener}
+   * so subsequent {@link #shorten(String)} calls produce import-aware short names.
+   */
   private void generateClassHeader(String className, Set<String> imports, String annos, TypeKind typeKind, String... supers) {
     generateFileHeader(className);
     String packageName = StringUtil.getPackageName(className);
@@ -404,6 +450,11 @@ public final class JavaParserGenerator extends Generator {
     }
   }
 
+  /**
+   * Emits one parser source file: imports, class header, the root-parser scaffolding (only for
+   * the grammar root parser), the per-rule parse methods, expression-rule roots, and finally the
+   * shared {@code Parser} lambda fields and meta-method fields collected during emission.
+   */
   public void generateParser(String parserClass, Collection<String> ownRuleNames) {
     List<String> parserImports = getRootAttribute(myFile, KnownAttribute.PARSER_IMPORTS).asStrings();
     boolean rootParser = parserClass.equals(myGrammarRootParser);
@@ -468,6 +519,10 @@ public final class JavaParserGenerator extends Generator {
     out("}");
   }
 
+  /**
+   * Emits the {@code static final Parser} fields collected in {@link #myParserLambdas},
+   * de-duplicating identical bodies so equal lambdas share a single field reference.
+   */
   private void generateParserLambdas(@NotNull String parserClass) {
     Map<String, String> reversedLambdas = new HashMap<>();
     take(myParserLambdas).forEach((name, body) -> {
@@ -482,6 +537,7 @@ public final class JavaParserGenerator extends Generator {
     });
   }
 
+  /** Renders {@code body} as a {@code Parser} instance — a Java 7+ lambda or, for {@code javaVersion <= 6}, an anonymous class. */
   private @NotNull String generateParserInstance(@NotNull String body) {
     return G.javaVersion > 6
            ? format("(%s, %s) -> %s", N.builder, N.level, body)
@@ -489,11 +545,17 @@ public final class JavaParserGenerator extends Generator {
                     shorten(JavaBnfConstants.PSI_BUILDER_CLASS), N.builder, N.level, body);
   }
 
+  /** Emits cached static {@code Parser} fields for parameter-free meta-method calls collected in {@link #myMetaMethodFields}. */
   private void generateMetaMethodFields() {
     String parserClassShortName = "Parser";
     take(myMetaMethodFields).forEach((field, call) -> out(String.format("private static final %s %s = %s;", parserClassShortName, field, call)));
   }
 
+  /**
+   * Emits the root parser body: {@code parse}/{@code parseLight} entry points, the
+   * {@code parse_root_} dispatcher (with extra-root branches for rules marked
+   * {@code extraRoot=true}), and the static {@code EXTENDS_SETS_} array.
+   */
   private void generateRootParserContent() {
     BnfRule rootRule = myFile.getRule(myGrammarRoot);
     List<BnfRule> extraRoots = new ArrayList<>();
@@ -593,6 +655,15 @@ public final class JavaParserGenerator extends Generator {
     // @formatter:on
   }
 
+  /**
+   * Emits the parser method body for {@code rule}'s expression. Handles all the generation
+   * concerns: meta-method wrapping, single-token shortcut returns, FIRST-set guards, section
+   * enter/exit with the right modifier flags ({@code _LEFT_}, {@code _COLLAPSE_}, {@code _AND_},
+   * {@code _NOT_}, {@code _UPPER_}), pin-on-success tracking for sequences, choice/sequence/
+   * optional/zero-or-more/one-or-more/and-not dispatch, hooks, and {@code recoverWhile} (with
+   * automatic, meta-parameterized, and explicit predicate variants). Recursively generates child
+   * helper methods after the main body.
+   */
   @SuppressWarnings("DuplicatedCode")
   @Override
   void generateNode(BnfRule rule, BnfExpression initialNode, String funcName, Set<BnfExpression> visited) {
@@ -821,6 +892,7 @@ public final class JavaParserGenerator extends Generator {
     generateNodeChildren(rule, funcName, children, visited);
   }
 
+  /** Java rendering of {@code !nextTokenIsFast(builder, t1, t2, ...)} for the auto-recovery predicate. */
   @Override
   public StringBuilder generateAutoRecoveryCall(List<String> tokenTypes){
     StringBuilder sb = new StringBuilder(format("!nextTokenIsFast(%s, ", N.builder));
@@ -829,6 +901,12 @@ public final class JavaParserGenerator extends Generator {
     return sb;
   }
 
+  /**
+   * Emits the inline FIRST-set check, grouped by {@link ConsumeType} so each group becomes one
+   * {@code nextTokenIs*(...)} call AND-ed together. Skipped when the FIRST set contains
+   * "matches any/eof", a sub-rule, or anything that doesn't reduce to a token element type, or
+   * when the set is larger than {@link GenOptions#generateFirstCheck}.
+   */
   @SuppressWarnings("DuplicatedCode")
   @Override
   public String generateFirstCheck(@NotNull BnfRule rule, String frameName, boolean skipIfOne) {
@@ -876,6 +954,11 @@ public final class JavaParserGenerator extends Generator {
     return dropFrameName && StringUtil.isEmpty(getAttribute(rule, KnownAttribute.NAME)) ? null : frameName;
   }
 
+  /**
+   * Returns the consume type that should be used when calling {@code rule}. A consume-type
+   * forced by an enclosing expression rule is honored only when {@code contextRule} is itself
+   * an expression rule; otherwise the rule's own default is used.
+   */
   private @NotNull ConsumeType getRuleConsumeType(@NotNull BnfRule rule, @Nullable BnfRule contextRule) {
     ConsumeType forcedConsumeType = ExpressionGeneratorHelper.fixForcedConsumeType(myExpressionHelper, rule, null, null);
     if (forcedConsumeType != null && contextRule != null && myExpressionHelper.getExpressionInfo(contextRule) == null) {
@@ -885,6 +968,7 @@ public final class JavaParserGenerator extends Generator {
     return ObjectUtils.chooseNotNull(forcedConsumeType, ConsumeType.forRule(rule));
   }
 
+  /** Collects meta-parameter placeholders ({@code <<x>>}) used in {@code expression} and returns their generated parameter names. */
   private @NotNull List<String> collectMetaParametersFormatted(@NotNull BnfRule rule, @Nullable BnfExpression expression) {
     if (expression == null) return Collections.emptyList();
     return map(GrammarUtil.collectMetaParameters(rule, expression),
@@ -926,6 +1010,14 @@ public final class JavaParserGenerator extends Generator {
     return new ConsumeTokenChoiceCall(consumeType, tokenSetName, N.builder);
   }
 
+  /**
+   * Java implementation of {@link Generator#generateNodeCall}: tokens become
+   * {@code consumeToken*}, sub-rules become method calls (cross-class qualified when needed),
+   * expression rules become {@code ExpressionMethodCall} with the priority offset,
+   * external rules go through {@link #generateExternalCall}, and meta-parameter references
+   * become {@code MetaParameterCall}. Falls through to a plain method call to {@code nextName}
+   * for "everything else".
+   */
   @Override
   @NotNull
   NodeCall generateNodeCall(@NotNull BnfRule rule,
@@ -1016,6 +1108,12 @@ public final class JavaParserGenerator extends Generator {
     }
   }
 
+  /**
+   * Resolves the consume type to use when emitting a call for {@code node} inside {@code rule}.
+   * A non-leading sequence child whose preceding alternatives can also start at the same token
+   * is forced back to {@link ConsumeType#DEFAULT} to avoid swallowing tokens belonging to a
+   * sibling alternative.
+   */
   private @NotNull ConsumeType getEffectiveConsumeType(@NotNull BnfRule rule,
                                                        @Nullable BnfExpression node,
                                                        @Nullable ConsumeType forcedConsumeType) {
@@ -1051,11 +1149,13 @@ public final class JavaParserGenerator extends Generator {
   }
 
 
+  /** Builds a {@code consumeToken(builder, ELEMENT_TYPE)} call and records {@code tokenName} as used in the grammar. */
   private @NotNull NodeCall generateConsumeToken(@NotNull ConsumeType consumeType, @NotNull String tokenName) {
     myTokensUsedInGrammar.add(tokenName);
     return new ConsumeTokenCall(consumeType, getElementType(tokenName), N.builder);
   }
 
+  /** Builds a {@code consumeToken(builder, "literal")} call for tokens given by their literal text rather than name. */
   private static @NotNull NodeCall generateConsumeTextToken(@NotNull ConsumeType consumeType,
                                                             @NotNull String tokenText,
                                                             @NotNull String stateHolder) {
@@ -1064,6 +1164,12 @@ public final class JavaParserGenerator extends Generator {
 
   /*ElementTypes******************************************************************/
 
+  /**
+   * Emits the element-type holder interface: composite element-type fields, token-type fields,
+   * the {@link #generateTokenSets() token sets} block, and (when generating PSI) optional
+   * {@code Classes} (element-type → impl class) and {@code Factory} (element-type → impl
+   * instantiation) inner classes.
+   */
   private void generateElementTypesHolder(String className,
                                           Map<String, BnfRule> sortedCompositeTypes,
                                           String tokenTypeFactory,
@@ -1237,6 +1343,7 @@ public final class JavaParserGenerator extends Generator {
     out("}");
   }
 
+  /** True if {@code tokenName} is a regexp token that matches whitespace, isn't referenced by the grammar, and isn't a generic identifier/number. */
   private boolean isIgnoredWhitespaceToken(@NotNull String tokenName, @NotNull String tokenText) {
     return isRegexpToken(tokenText) &&
            !myTokensUsedInGrammar.contains(tokenName) &&
@@ -1244,6 +1351,7 @@ public final class JavaParserGenerator extends Generator {
            !matchesAny(getRegexpTokenRegexp(tokenText), "a", "1", "_", ".");
   }
 
+  /** Emits the {@code TokenSets} inner interface holding the {@code TokenSet} constants registered via {@link #generateTokenChoiceCall}. */
   private void generateTokenSets() {
     if (myChoiceTokenSets.isEmpty()) {
       return;
@@ -1260,6 +1368,7 @@ public final class JavaParserGenerator extends Generator {
   }
 
   /*PSI******************************************************************/
+  /** Emits the PSI interface and impl for each rule, plus the visitor when one is configured. */
   private void generatePsi(Map<String, BnfRule> sortedPsiRules) throws IOException {
     checkClassAvailability(myPsiImplUtilClass);
     myRulesMethodsHelper.buildMaps(sortedPsiRules.values());
@@ -1295,6 +1404,7 @@ public final class JavaParserGenerator extends Generator {
   }
 
 
+  /** Emits the public PSI interface for {@code rule}: super-interfaces (with stub-aware additions) and rule accessor signatures. */
   private void generatePsiIntf(BnfRule rule, RuleInfo info) {
     String psiClass = info.intfClass;
     String stubClass = info.stub;
@@ -1316,6 +1426,12 @@ public final class JavaParserGenerator extends Generator {
     out("}");
   }
 
+  /**
+   * Emits the PSI impl class for {@code rule}: extends/implements clause from
+   * {@link RuleInfo#realSuperClass}, constructors that mirror those of the (eventual) base
+   * class, optional {@code accept(Visitor)} dispatch, and rule accessor implementations.
+   * Detects and warns on cyclic {@code mixin}/{@code extends} chains.
+   */
   private void generatePsiImpl(@NotNull BnfRule rule, @NotNull RuleInfo info) {
     String psiClass = info.implClass;
     String superInterface = info.intfClass;
@@ -1456,6 +1572,7 @@ public final class JavaParserGenerator extends Generator {
     out("}");
   }
 
+  /** Emits accessor and util methods for {@code rule}'s PSI interface ({@code intf=true}) or impl ({@code intf=false}). */
   private void generatePsiClassMethods(BnfRule rule, RuleInfo info, boolean intf) {
     Set<String> visited = new TreeSet<>();
     boolean mixedAST = info.mixedAST;
@@ -1497,6 +1614,7 @@ public final class JavaParserGenerator extends Generator {
     }
   }
 
+  /** Collects every type name that {@code rule}'s generated PSI accessors and mixin/util methods reference, so callers can build the import list. */
   public Collection<String> getRuleMethodTypesToImport(BnfRule rule) {
     Set<String> result = new TreeSet<>();
 
@@ -1533,6 +1651,11 @@ public final class JavaParserGenerator extends Generator {
     return result;
   }
 
+  /**
+   * Adds every reachable type name from {@code methods} (return type, generics, parameter types,
+   * exceptions) to {@code result}. {@code isInPsiUtil} skips the first PSI-util parameter pair
+   * since it represents the {@code this} target, not a real parameter.
+   */
   private void collectMethodTypesToImport(@NotNull List<NavigatablePsiElement> methods, boolean isInPsiUtil, @NotNull Set<String> result) {
     for (NavigatablePsiElement method : methods) {
       List<String> types = myJavaHelper.getMethodTypes(method);
@@ -1560,6 +1683,7 @@ public final class JavaParserGenerator extends Generator {
   }
 
 
+  /** Emits a single rule- or token-accessor method (e.g. {@code getFoo()}, {@code getFooList()}) for the PSI interface or impl. */
   private void generatePsiAccessor(BnfRule rule, RuleMethodsHelper.MethodInfo methodInfo, boolean intf, boolean mixedAST) {
     Cardinality type = methodInfo.cardinality;
     boolean isToken = methodInfo.rule == null;
@@ -1593,6 +1717,11 @@ public final class JavaParserGenerator extends Generator {
     newLine();
   }
 
+  /**
+   * Renders the body of a PSI accessor — a {@code findChildByType}, {@code findChildByClass},
+   * {@code PsiTreeUtil.getChildOfType} or stub-aware variant — depending on cardinality, whether
+   * the rule has stubs, whether the AST is mixed, and the legacy/no-stubs fallback.
+   */
   private String generatePsiAccessorImplCall(@NotNull BnfRule rule, @NotNull RuleMethodsHelper.MethodInfo methodInfo, boolean mixedAST) {
     boolean isToken = methodInfo.rule == null;
 
@@ -1630,6 +1759,7 @@ public final class JavaParserGenerator extends Generator {
     return required && !mixedAST ? "notNullChild(" + result + ")" : result;
   }
 
+  /** Return type of an accessor for {@code rule} — its first {@code implements} entry for external rules, its PSI interface otherwise. */
   private @NotNull String getAccessorType(@NotNull BnfRule rule) {
     if (BnfRules.isExternal(rule)) {
       Pair<String, String> first = ContainerUtil.getFirstItem(getAttribute(rule, KnownAttribute.IMPLEMENTS));
@@ -1640,6 +1770,11 @@ public final class JavaParserGenerator extends Generator {
     }
   }
 
+  /**
+   * Walks a slash-separated path of accessor names ({@code "foo/bar[0]/baz"}) starting at
+   * {@code startRule}, yielding the resolved {@link RuleMethodsHelper.MethodInfo} for each step
+   * (or the path element string for empty/index segments, or {@code null} when resolution fails).
+   */
   private JBIterable<?> resolveUserPsiPathMethods(BnfRule startRule,
                                                   String[] splitPath) {
     BnfRule[] targetRule = {startRule};
@@ -1656,6 +1791,12 @@ public final class JavaParserGenerator extends Generator {
     });
   }
 
+  /**
+   * Emits a user-defined accessor whose body chains through a {@code methods} attribute path
+   * (e.g. {@code "foo/bar[last]"}). Reports a warning per attribute on the first invalid path
+   * step (unknown rule, index on a non-list, missing index on a list, suppressed accessor, …)
+   * and aborts emission of that accessor.
+   */
   private void generateUserPsiAccessors(BnfRule startRule, RuleMethodsHelper.MethodInfo methodInfo, boolean intf, boolean mixedAST) {
     StringBuilder sb = new StringBuilder();
     BnfRule targetRule = startRule;
@@ -1803,6 +1944,11 @@ public final class JavaParserGenerator extends Generator {
     newLine();
   }
 
+  /**
+   * Emits a method that delegates to a mixin or {@code psiImplUtil} static helper, mirroring its
+   * signature, generics, annotations, and exceptions. {@code isInPsiUtil=true} drops the first
+   * helper parameter (the {@code this} target) when forwarding the call.
+   */
   private void generateUtilMethod(String methodName,
                                   NavigatablePsiElement method,
                                   boolean intf,
@@ -1853,6 +1999,12 @@ public final class JavaParserGenerator extends Generator {
   }
 
   /*Syntax******************************************************************/
+  /**
+   * Emits the Syntax-API element-type converter class — a registry mapping each generated
+   * Syntax {@code KtElementType} (and, when token types are generated, each token element type)
+   * to its legacy {@code IElementType} counterpart. Used only when {@link GenOptions.ParserApi} is
+   * {@code Syntax}.
+   */
   private void generateElementTypesConverter(String elementTypesConverter,
                                              String typeHolderClass,
                                              String syntaxElementTypeHolderClass,

--- a/generator/src/org/intellij/grammar/generator/KotlinParserGenerator.java
+++ b/generator/src/org/intellij/grammar/generator/KotlinParserGenerator.java
@@ -164,7 +164,7 @@ public final class KotlinParserGenerator extends Generator {
         stubName = stubClass;
       }
       else if (implSuper.indexOf("<") < implSuper.indexOf(">") &&
-               !myJavaHelper
+               !helperFor(rule, KnownAttribute.MIXIN)
                  .findClassMethods(implSuperRaw, JavaHelper.MethodType.INSTANCE, "getParentByStub", 0).isEmpty()) {
         stubName = implSuper.substring(implSuper.indexOf("<") + 1, implSuper.indexOf(">"));
       }

--- a/generator/src/org/intellij/grammar/generator/KotlinParserGenerator.java
+++ b/generator/src/org/intellij/grammar/generator/KotlinParserGenerator.java
@@ -45,15 +45,24 @@ import static org.intellij.grammar.psi.BnfAttributes.getRootAttribute;
 import static org.intellij.grammar.psi.BnfRules.getEffectiveSuperRule;
 import static org.intellij.grammar.psi.BnfTypes.*;
 
-
-/// A Kotlin parser generator implementation.
-///
-/// Implementation notes:
-/// 1. A method's name starts with `generate` if it either calls the
-///   [Generator#out] method or calls another `generate*` method.
-/// 2. `build*` methods are generally used for building strings that
-///   are then going to be outputted via one of the `generate*`
-///   methods to the file.
+/**
+ * [Generator] implementation that emits Kotlin parser sources targeting the Syntax Engine
+ * API (`SyntaxParserRuntime`, `SyntaxElementType`, etc.) rather than the legacy `PsiBuilder`
+ * world.
+ * <p>
+ * [#generate()] writes the parser file(s), then the syntax element-type holder, and finally
+ * delegates PSI emission to a fresh [JavaParserGenerator] — Kotlin parser generation does not
+ * produce PSI of its own, but it does discover simple tokens along the way that the Java
+ * generator needs, so [JavaParserGenerator#replaceSimpleTokes] is called before
+ * [JavaParserGenerator#generatePsiOnly] runs.
+ * <p>
+ * Implementation notes:
+ * 1. A method's name starts with `generate` if it either calls the
+ * [Generator#out] method or calls another `generate*` method.
+ * 2. `build*` methods are generally used for building strings that
+ * are then going to be outputted via one of the `generate*`
+ * methods to the file.
+ */
 public final class KotlinParserGenerator extends Generator {
   private static final @NotNull String HORIZONTAL_SEPARATOR = "/* ********************************************************** */";
 
@@ -118,14 +127,17 @@ public final class KotlinParserGenerator extends Generator {
     calcAbstractRules();
   }
 
+  /** Builds a `consumeToken(runtime, "literal")` call for tokens given by their literal text. */
   private @NotNull NodeCall getConsumeTextToken(@NotNull ConsumeType consumeType, @NotNull String tokenText) {
     return new KotlinConsumeTokenCall(consumeType, "\"" + tokenText + "\"", N);
   }
 
+  /** Short name of the generated element-types holder object, used to qualify element-type references. */
   private @NotNull String shortElementTypesHolderName() {
     return StringUtil.getShortName(myElementTypesHolderName);
   }
 
+  /** Marks rules that are reused as another rule's `elementType`, so they keep an element-type entry even when `fake`. */
   private void calcFakeRulesWithType() {
     for (final var rule : myFile.getRules()) {
       BnfRule r = myFile.getRule(getAttribute(rule, KnownAttribute.ELEMENT_TYPE));
@@ -134,6 +146,10 @@ public final class KotlinParserGenerator extends Generator {
     }
   }
 
+  /**
+   * Resolves each rule's effective stub class — explicit `stubClass`, inherited from the
+   * effective super-rule, or extracted as the type argument of a stub-aware base class.
+   */
   private void calcRulesStubNames() {
     for (BnfRule rule : myFile.getRules()) {
       RuleInfo info = this.ruleInfo(rule);
@@ -196,6 +212,11 @@ public final class KotlinParserGenerator extends Generator {
     }
   }
 
+  /**
+   * Emits one Kotlin parser source: file header, package, imports, the `object` declaration,
+   * the root-parser scaffolding (only for the grammar root parser), per-rule parse functions,
+   * expression-rule roots, and the trailing parser-lambda / meta-method fields.
+   */
   private void generateParserImpl(String parserClass, Collection<String> ownRuleNames) {
     // file header
     generateFileHeader(parserClass);
@@ -264,6 +285,10 @@ public final class KotlinParserGenerator extends Generator {
     out("}");
   }
 
+  /**
+   * Emits the root-only members of the parser object: `parse`, `parse_root_`, and (when the
+   * extends-graph is non-empty) the `EXTENDS_SETS_` array.
+   */
   private void generateRootParserDefinitions() {
     generateParse();
     generateParseRoot();
@@ -341,6 +366,13 @@ public final class KotlinParserGenerator extends Generator {
     newLine();
   }
 
+  /**
+   * Kotlin counterpart of [JavaParserGenerator#generateNode]: emits the parse function for
+   * `rule`'s expression including meta-method wrapping, single-token shortcut returns,
+   * FIRST-set guards, `enter_section_`/`exit_section_` with appropriate modifier flags,
+   * pin-on-success tracking for sequences, choice/sequence/optional/zero-or-more/one-or-more/
+   * and-not dispatch, hooks, and `recoverWhile`. Recursively emits child helper functions.
+   */
   @SuppressWarnings("DuplicatedCode")
   @Override
   protected void generateNode(BnfRule rule, @NotNull BnfExpression initialNode, String funcName, Set<BnfExpression> visited) {
@@ -599,6 +631,12 @@ public final class KotlinParserGenerator extends Generator {
     generateNodeChildren(rule, funcName, children, visited);
   }
 
+  /**
+   * Emits the operator-precedence climbing parser for an expression rule:
+   * the entry function (atoms + prefix operators), the kernel loop (binary/n-ary/postfix
+   * operators, with priority and right-associativity checks), and the per-operator helper
+   * functions (atom bodies and prefix operator bodies).
+   */
   private void generateExpressionRoot(@NotNull ExpressionInfo info) {
     final var opCalls = buildCallMap(info);
     final var sortedOpCalls = opCalls.keySet();
@@ -766,6 +804,10 @@ public final class KotlinParserGenerator extends Generator {
     }
   }
 
+  /**
+   * Groups expression-rule operators by the rendered text of their operator call so that
+   * operators sharing the same opening token are emitted together in the kernel loop.
+   */
   private @NotNull Map<String, List<OperatorInfo>> buildCallMap(@NotNull ExpressionInfo info) {
     final var result = new LinkedHashMap<String, List<OperatorInfo>>();
     for (final var bnfRule : info.priorityMap.keySet()) {
@@ -778,6 +820,10 @@ public final class KotlinParserGenerator extends Generator {
     return result;
   }
 
+  /**
+   * Emits the `internal val ... : Parser` fields collected in [Generator#myParserLambdas],
+   * de-duplicating identical bodies so equal lambdas share a field reference.
+   */
   private void generateParserLambdas(@NotNull String parserClass) {
     Map<String, String> reversedLambdas = new HashMap<>();
     take(myParserLambdas).forEach((name, body) -> {
@@ -809,6 +855,10 @@ public final class KotlinParserGenerator extends Generator {
     out("}");
   }
 
+  /**
+   * Emits cached `private val ... : Parser` fields for parameter-free meta-method calls
+   * collected in [Generator#myMetaMethodFields].
+   */
   private void generateMetaMethodFields() {
     take(myMetaMethodFields).forEach(
       (field, call) -> out("private val %s: Parser = %s", field, call)
@@ -839,6 +889,7 @@ public final class KotlinParserGenerator extends Generator {
     out(")");
   }
   
+  /** Kotlin rendering of `!runtime.nextTokenIsFast(t1, t2, ...)` for the auto-recovery predicate. */
   @Override
   public StringBuilder generateAutoRecoveryCall(List<String> tokenTypes){
     StringBuilder sb = new StringBuilder(format("!%s.nextTokenIsFast(", N.runtime));
@@ -847,6 +898,12 @@ public final class KotlinParserGenerator extends Generator {
     return sb;
   }
 
+  /**
+   * Kotlin counterpart of [JavaParserGenerator#generateFirstCheck]: emits the inline FIRST-set
+   * guard, grouped by [ConsumeType] so each group becomes one `runtime.nextTokenIs*(...)` call
+   * AND-ed together. Skipped when the FIRST set contains "matches any/eof", a sub-rule, or
+   * anything not reducing to a token, or when the set exceeds [GenOptions#generateFirstCheck].
+   */
   @SuppressWarnings("DuplicatedCode")
   @Override
   protected @Nullable String generateFirstCheck(@NotNull BnfRule rule, @Nullable String frameName, boolean skipIfOne) {
@@ -907,6 +964,11 @@ public final class KotlinParserGenerator extends Generator {
 
   // region Element Types Generation
 
+  /**
+   * Top-level driver for emitting the syntax element-type holder file: collects composite
+   * element types and their per-rule factory overrides, opens the output, and delegates to
+   * [#generateElementTypesImpl].
+   */
   private void generateElementTypes() throws IOException {
     final var sortedCompositeTypes = new TreeSet<String>();
     final var typeToFactoryMap = new HashMap<String, String>();
@@ -933,6 +995,11 @@ public final class KotlinParserGenerator extends Generator {
     }
   }
 
+  /**
+   * Emits the body of the element-types Kotlin `object`: composite element-type vals (using
+   * either the per-rule factory or the default `KtElementType` constructor), token-type vals,
+   * and token sets registered for token-choice expressions.
+   */
   private void generateElementTypesImpl(@NotNull String objectName, @NotNull Set<String> sortedCompositeTypes, @NotNull Map<String, String> typeToFactoryMap) {
     // file header
     generateFileHeader(objectName);
@@ -981,6 +1048,10 @@ public final class KotlinParserGenerator extends Generator {
     out("}");
   }
 
+  /**
+   * Emits a `KtElementType` constructor call per simple token, skipping unused regex tokens
+   * that match only whitespace.
+   */
   private void generateTokenDefinitions(@NotNull NameShortener nameShortener) {
     if (mySimpleTokens.isEmpty()) return;
     newLine();
@@ -997,6 +1068,10 @@ public final class KotlinParserGenerator extends Generator {
     }
   }
 
+  /**
+   * Emits the `SyntaxElementTypeSet` vals registered via [Generator#generateTokenChoiceCall],
+   * reusing names when two token sets share the same body.
+   */
   private void generateTokenSets(@NotNull NameShortener shortener) {
     if (myChoiceTokenSets.isEmpty()) return;
     newLine();
@@ -1051,6 +1126,11 @@ public final class KotlinParserGenerator extends Generator {
     return "{ %s, %s -> %s }".formatted(N.runtime, N.level, body);
   }
 
+  /**
+   * Returns the consume type to use when calling `rule`. A consume type forced by an
+   * enclosing expression rule is honored only when `contextRule` is itself an expression rule;
+   * otherwise the rule's own default applies.
+   */
   private @NotNull ConsumeType getRuleConsumeType(@NotNull BnfRule rule, @Nullable BnfRule contextRule) {
     ConsumeType forcedConsumeType = ExpressionGeneratorHelper.fixForcedConsumeType(myExpressionHelper, rule, null, null);
     if (forcedConsumeType != null && contextRule != null && myExpressionHelper.getExpressionInfo(contextRule) == null) {
@@ -1060,6 +1140,10 @@ public final class KotlinParserGenerator extends Generator {
     return ObjectUtils.chooseNotNull(forcedConsumeType, ConsumeType.forRule(rule));
   }
 
+  /**
+   * Collects meta-parameter placeholders (`<<x>>`) used in `expression` and returns their
+   * generated Kotlin parameter names.
+   */
   private @NotNull List<String> collectMetaParametersFormatted(@NotNull BnfRule rule, @Nullable BnfExpression expression) {
     if (expression == null) return Collections.emptyList();
     return map(GrammarUtil.collectMetaParameters(rule, expression),
@@ -1110,6 +1194,12 @@ public final class KotlinParserGenerator extends Generator {
     return new KotlinConsumeTokenChoiceCall(consumeType, shortElementTypesHolderName() + "." + tokenSetName, N);
   }
 
+  /**
+   * Kotlin implementation of [Generator#generateNodeCall]: tokens become `consumeToken*`,
+   * sub-rules become method calls (cross-class qualified when needed), expression rules
+   * become `ExpressionMethodCall` with the priority offset, external rules go through
+   * [#generateExternalCall], and meta-parameter references become `MetaParameterCall`.
+   */
   @Override
   @NotNull NodeCall generateNodeCall(@NotNull BnfRule rule,
                                      @Nullable BnfExpression node,
@@ -1200,6 +1290,11 @@ public final class KotlinParserGenerator extends Generator {
     }
   }
 
+  /**
+   * Resolves the consume type for emitting a call for `node` inside `rule`. A non-leading
+   * sequence child whose preceding alternatives can also start at the same token is forced
+   * back to [ConsumeType#DEFAULT] to avoid swallowing tokens belonging to a sibling alternative.
+   */
   private @NotNull ConsumeType getEffectiveConsumeType(@NotNull BnfRule rule,
                                                        @Nullable BnfExpression node,
                                                        @Nullable ConsumeType forcedConsumeType) {
@@ -1218,6 +1313,11 @@ public final class KotlinParserGenerator extends Generator {
     return fixed != null ? fixed : ConsumeType.forRule(rule);
   }
 
+  /**
+   * Wraps [Generator#generateExternalCall] for the Kotlin Syntax target: rewrites runtime
+   * helpers (`eof`, `advanceToken`) as direct runtime calls, and routes other plain external
+   * calls through the configured `syntaxParserUtilObject` so they pick up its receiver.
+   */
   private @NotNull NodeCall generateExternalCall(@NotNull BnfRule rule,
                                                @NotNull List<BnfExpression> expressions,
                                                @NotNull String nextName) {
@@ -1241,10 +1341,15 @@ public final class KotlinParserGenerator extends Generator {
     return externalCall;
   }
 
+  /**
+   * True if `methodName` is a `SyntaxGeneratedParserRuntime` helper that should be invoked
+   * directly on the runtime rather than via the configured parser-util object.
+   */
   private boolean isRuntimeMethod(String methodName) {
     return mySGPRMethods.contains(methodName);
   }
 
+  /** Builds a `consumeToken(runtime, ElementTypes.NAME)` call and records `tokenName` as used. */
   private @NotNull NodeCall createConsumeToken(@NotNull ConsumeType consumeType, @NotNull String tokenName) {
     myTokensUsedInGrammar.add(tokenName);
     return new KotlinConsumeTokenCall(consumeType, shortElementTypesHolderName() + "." + getElementType(tokenName), N);
@@ -1252,6 +1357,10 @@ public final class KotlinParserGenerator extends Generator {
 
   // region Utils
 
+  /**
+   * True if `tokenName` is a regexp token matching whitespace, isn't referenced by the
+   * grammar, and isn't a generic identifier/number — those are skipped during emission.
+   */
   private boolean isIgnoredWhitespaceToken(@NotNull String tokenName, @NotNull String tokenText) {
     return isRegexpToken(tokenText) &&
            !myTokensUsedInGrammar.contains(tokenName) &&

--- a/generator/src/org/intellij/grammar/generator/KotlinParserGenerator.java
+++ b/generator/src/org/intellij/grammar/generator/KotlinParserGenerator.java
@@ -12,6 +12,7 @@ import com.intellij.util.ObjectUtils;
 import com.intellij.util.SmartList;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.JBIterable;
+import org.intellij.grammar.BnfPathsResolution;
 import org.intellij.grammar.KnownAttribute;
 import org.intellij.grammar.analysis.BnfFirstNextAnalyzer;
 import org.intellij.grammar.generator.NodeCalls.*;
@@ -70,8 +71,7 @@ public final class KotlinParserGenerator extends Generator {
    * Name of the class containing all the generated element types.
    */
   private final @NotNull String myElementTypesHolderName;
-  private final @NotNull String myPsiOutputPath;
-  
+
   private final @NotNull String myParserUtil;
 
   private final @NotNull Collection<String> mySGPRMethods = Arrays.asList("eof", "advanceToken");
@@ -83,24 +83,19 @@ public final class KotlinParserGenerator extends Generator {
   private final @NotNull Set<String> myTokensUsedInGrammar = new LinkedHashSet<>();
 
   private final ExpressionHelper myExpressionHelper;
-  private final JavaHelper myJavaHelper;
 
   public KotlinParserGenerator(@NotNull BnfFile psiFile,
                                @NotNull String sourcePath,
-                               @NotNull String outputPath,
-                               @NotNull String psiOutputPath,
                                @NotNull String packagePrefix,
-                               @NotNull OutputOpener outputOpener
-  ) {
-    super(psiFile, sourcePath, outputPath, packagePrefix, "kt", outputOpener, KotlinNameRenderer.INSTANCE);
+                               @NotNull OutputOpener outputOpener,
+                               @NotNull BnfPathsResolution paths) {
+    super(psiFile, sourcePath, packagePrefix, "kt", outputOpener, KotlinNameRenderer.INSTANCE, paths);
 
     // TODO: consider creating kotlin specific attributes for this
     myElementTypesHolderName = getRootAttribute(myFile, KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_CLASS);
     myParserUtil = getRootAttribute(myFile, KnownAttribute.SYNTAX_PARSER_UTIL_OBJECT);
-    myPsiOutputPath = (psiOutputPath.isEmpty()) ? myOutputPath : psiOutputPath;
 
     myExpressionHelper = new ExpressionHelper(myFile, myGraphHelper, this::addWarning);
-    myJavaHelper = JavaHelper.getJavaHelper(myFile);
 
     for (final var rule : psiFile.getRules()) {
       final var ruleName = rule.getName();
@@ -169,7 +164,8 @@ public final class KotlinParserGenerator extends Generator {
         stubName = stubClass;
       }
       else if (implSuper.indexOf("<") < implSuper.indexOf(">") &&
-               !myJavaHelper.findClassMethods(implSuperRaw, JavaHelper.MethodType.INSTANCE, "getParentByStub", 0).isEmpty()) {
+               !myJavaHelper
+                 .findClassMethods(implSuperRaw, JavaHelper.MethodType.INSTANCE, "getParentByStub", 0).isEmpty()) {
         stubName = implSuper.substring(implSuper.indexOf("<") + 1, implSuper.indexOf(">"));
       }
       else {
@@ -189,8 +185,8 @@ public final class KotlinParserGenerator extends Generator {
     if (myGrammarRoot != null && (G.generateTokenTypes || G.generateElementTypes)) {
       generateElementTypes();
     }
-    if (myGrammarRoot != null && (G.generatePsi)){
-      JavaParserGenerator javaParserGenerator = new JavaParserGenerator(myFile, mySourcePath, myPsiOutputPath, myPackagePrefix, myOpener);
+    if (myGrammarRoot != null && (G.generatePsi)) {
+      JavaParserGenerator javaParserGenerator = new JavaParserGenerator(myFile, mySourcePath, myPackagePrefix, myOpener, myPaths);
       javaParserGenerator.replaceSimpleTokes(mySimpleTokens);
       javaParserGenerator.generatePsiOnly();
     }
@@ -202,7 +198,7 @@ public final class KotlinParserGenerator extends Generator {
   public void generateParser() throws IOException {
     Map<String, Set<RuleInfo>> classified = ContainerUtil.classify(myRuleInfos.values().iterator(), o -> o.parserClass);
     for (String className : ContainerUtil.sorted(classified.keySet())) {
-      openOutput(className);
+      openOutput(className, myPaths.pathString(KnownAttribute.PARSER_OUTPUT_PATH));
       try {
         generateParserImpl(className, map(classified.get(className), it -> it.name));
       }
@@ -986,7 +982,7 @@ public final class KotlinParserGenerator extends Generator {
         sortedCompositeTypes.add(elementType);
       }
     }
-    openOutput(myElementTypesHolderName);
+    openOutput(myElementTypesHolderName, myPaths.pathString(KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
     try {
       generateElementTypesImpl(myElementTypesHolderName, sortedCompositeTypes, typeToFactoryMap);
     }

--- a/generator/src/org/intellij/grammar/generator/batch/BatchGenerationContext.java
+++ b/generator/src/org/intellij/grammar/generator/batch/BatchGenerationContext.java
@@ -17,23 +17,39 @@ import java.util.Map;
  * Pre-computed, immutable context passed from the write-lock preparation phase to the
  * background generation task.
  *
- * @param project    the current project
- * @param bnfFiles   the grammar files selected for generation, in selection order
- * @param rootMap    maps each {@code .bnf} file to the VFS directory where the parser class will
- *                   be written; derived from {@link KnownAttribute#PARSER_CLASS}.
- *                   A {@code null} value means the target directory could not be created.
- * @param psiRootMap maps each {@code .bnf} file to the VFS directory where PSI interface/class
- *                   files will be written; derived from {@link KnownAttribute#PSI_OUTPUT_PATH}.
- *                   {@code null} value means PSI output goes to the same directory as the parser.
- * @param packageMap maps each parser output directory to the Java package name the IDE's
- *                   {@link PackageIndex} assigns to it; used as a prefix when the generator
- *                   computes fully-qualified class names for nested source roots.
+ * @param project                          the current project
+ * @param bnfFiles                         the grammar files selected for generation, in selection order
+ * @param rootMap                          maps each {@code .bnf} file to the VFS directory where the parser class
+ *                                         will be written. Derived from {@link KnownAttribute#PARSER_OUTPUT_PATH}
+ *                                         when set, otherwise from {@link KnownAttribute#PARSER_CLASS}'s package.
+ *                                         A {@code null} value means the target directory could not be created.
+ * @param psiRootMap                       maps each {@code .bnf} file to the VFS directory where PSI interface/class
+ *                                         files will be written; from {@link KnownAttribute#PSI_OUTPUT_PATH}.
+ *                                         {@code null} value means PSI output goes to the same directory as the parser.
+ * @param elementTypeHolderRootMap         maps each {@code .bnf} file to the VFS directory where the Java
+ *                                         {@code IElementType} holder will be written; from
+ *                                         {@link KnownAttribute#ELEMENT_TYPE_HOLDER_OUTPUT_PATH}. {@code null} = use the
+ *                                         generator's default (parser dir in Java mode, PSI dir in Kotlin mode).
+ * @param syntaxElementTypeHolderRootMap   maps each {@code .bnf} file to the VFS directory where the Kotlin
+ *                                         syntax-element-type holder will be written; from
+ *                                         {@link KnownAttribute#SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH}. {@code null} =
+ *                                         use the parser dir.
+ * @param converterFactoryRootMap          maps each {@code .bnf} file to the VFS directory where the
+ *                                         element-type converter factory will be written; from
+ *                                         {@link KnownAttribute#ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH}. {@code null}
+ *                                         = use the PSI dir.
+ * @param packageMap                       maps each parser output directory to the Java package name the IDE's
+ *                                         {@link PackageIndex} assigns to it; used as a prefix when the generator
+ *                                         computes fully-qualified class names for nested source roots.
  */
 public record BatchGenerationContext(
   @NotNull Project project,
   @NotNull List<VirtualFile> bnfFiles,
   @NotNull Map<VirtualFile, VirtualFile> rootMap,
   @NotNull Map<VirtualFile, VirtualFile> psiRootMap,
+  @NotNull Map<VirtualFile, VirtualFile> elementTypeHolderRootMap,
+  @NotNull Map<VirtualFile, VirtualFile> syntaxElementTypeHolderRootMap,
+  @NotNull Map<VirtualFile, VirtualFile> converterFactoryRootMap,
   @NotNull Map<VirtualFile, String> packageMap
 ) {
 }

--- a/generator/src/org/intellij/grammar/generator/batch/BnfGenerationService.java
+++ b/generator/src/org/intellij/grammar/generator/batch/BnfGenerationService.java
@@ -16,16 +16,20 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.util.concurrency.annotations.RequiresWriteLock;
+import org.intellij.grammar.BnfPaths;
+import org.intellij.grammar.BnfPathsResolution;
 import org.intellij.grammar.KnownAttribute;
 import org.intellij.grammar.generator.*;
 import org.intellij.grammar.psi.BnfAttributes;
 import org.intellij.grammar.psi.BnfFile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.*;
 
-import static org.intellij.grammar.generator.batch.FileGeneratorUtil.getTargetDirectoryFor;
 import static org.intellij.grammar.psi.BnfAttributes.getRootAttribute;
 
 /**
@@ -72,19 +76,14 @@ public class BnfGenerationService {
     if (target == null) {
       return SingleGrammarGenerationReport.notFound();
     }
+    // Every output folder (parser, PSI, IElement-type holder, syntax-type holder, converter factory)
+    // is registered in `targets` so the IDE refreshes each of them after generation.
     List<VirtualFile> targets = new ArrayList<>();
-    targets.add(target);
-
-    File genDir = new File(VfsUtilCore.virtualToIoFile(target).getAbsolutePath());
-    VirtualFile psiTarget = context.psiRootMap().get(bnfVirtualFile);
-    File psiGenDir;
-    if (psiTarget != null) {
-      psiGenDir = new File(VfsUtilCore.virtualToIoFile(psiTarget).getAbsolutePath());
-      targets.add(psiTarget);
-    }
-    else {
-      psiGenDir = genDir;
-    }
+    File genDir = collectTarget(target, targets);
+    collectOptionalTarget(context.psiRootMap().get(bnfVirtualFile), targets);
+    collectOptionalTarget(context.elementTypeHolderRootMap().get(bnfVirtualFile), targets);
+    collectOptionalTarget(context.syntaxElementTypeHolderRootMap().get(bnfVirtualFile), targets);
+    collectOptionalTarget(context.converterFactoryRootMap().get(bnfVirtualFile), targets);
 
     String packagePrefix = context.packageMap().get(target);
     List<File> files = new ArrayList<>();
@@ -96,7 +95,7 @@ public class BnfGenerationService {
       PsiFile bnfPsiFile = psiManager.findFile(bnfVirtualFile);
       if (!(bnfPsiFile instanceof BnfFile)) return;
       try {
-        Generator generator = createGenerator((BnfFile)bnfPsiFile, sourcePath, genDir, psiGenDir, packagePrefix, files);
+        Generator generator = createGenerator((BnfFile)bnfPsiFile, sourcePath, packagePrefix, files);
         generator.generate();
       }
       catch (Exception ex) {
@@ -111,21 +110,34 @@ public class BnfGenerationService {
     return new SingleGrammarGenerationReport(false, targets, files, bytesWritten, duration, genDir);
   }
 
+  /**
+   * Returns the on-disk {@link File} for {@code vf} and registers it in {@code targetsCollector}
+   * (deduped) so the IDE refreshes that directory after generation.
+   */
+  private static @NotNull File collectTarget(@NotNull VirtualFile vf, @NotNull List<VirtualFile> targetsCollector) {
+    if (!targetsCollector.contains(vf)) targetsCollector.add(vf);
+    return new File(VfsUtilCore.virtualToIoFile(vf).getAbsolutePath());
+  }
+
+  /** Nullable variant: returns {@code null} when {@code vf} is null, otherwise delegates to {@link #collectTarget}. */
+  private static @Nullable File collectOptionalTarget(@Nullable VirtualFile vf, @NotNull List<VirtualFile> targetsCollector) {
+    return vf == null ? null : collectTarget(vf, targetsCollector);
+  }
+
   public static @NotNull Generator createGenerator(@NotNull BnfFile bnfFile,
                                                    @NotNull String sourcePath,
-                                                   @NotNull File genDir,
-                                                   @NotNull File psiGenDir,
                                                    @NotNull String packagePrefix,
                                                    @NotNull List<? super File> files) {
     OutputOpener opener = (className, fileToOpen, myBnfFile) -> {
       files.add(fileToOpen);
       return OutputOpener.DEFAULT.openOutput(className, fileToOpen, myBnfFile);
     };
+    BnfPathsResolution paths = BnfPaths.resolve(bnfFile);
     if (BnfAttributes.useSyntaxApi(bnfFile)) {
-      return new KotlinParserGenerator(bnfFile, sourcePath, genDir.getPath(), psiGenDir.getPath(), packagePrefix, opener);
+      return new KotlinParserGenerator(bnfFile, sourcePath, packagePrefix, opener, paths);
     }
     else {
-      return new JavaParserGenerator(bnfFile, sourcePath, genDir.getPath(), packagePrefix, opener);
+      return new JavaParserGenerator(bnfFile, sourcePath, packagePrefix, opener, paths);
     }
   }
 
@@ -135,27 +147,47 @@ public class BnfGenerationService {
 
     Map<VirtualFile, VirtualFile> rootMap = new LinkedHashMap<>();
     Map<VirtualFile, VirtualFile> psiRootMap = new LinkedHashMap<>();
+    Map<VirtualFile, VirtualFile> etHolderMap = new LinkedHashMap<>();
+    Map<VirtualFile, VirtualFile> syntaxHolderMap = new LinkedHashMap<>();
+    Map<VirtualFile, VirtualFile> converterMap = new LinkedHashMap<>();
     Map<VirtualFile, String> packageMap = new LinkedHashMap<>();
 
     for (VirtualFile file : bnfFiles) {
       if (!file.isValid()) continue;
 
       PsiFile bnfFile = PsiManager.getInstance(project).findFile(file);
-      if (!(bnfFile instanceof BnfFile)) continue;
+      if (!(bnfFile instanceof BnfFile bnf)) continue;
 
-      String parserClass = getRootAttribute(bnfFile, KnownAttribute.PARSER_CLASS);
-      boolean preferGenRoot = true; // todo file.getFileType() == BnfFileType.INSTANCE || file.getFileType() == JFlexFileType.INSTANCE;
-      VirtualFile target =
-        getTargetDirectoryFor(project, file, StringUtil.getShortName(parserClass) + ".java", StringUtil.getPackageName(parserClass), true,
-                              preferGenRoot);
-      String psiOutput = getRootAttribute(bnfFile, KnownAttribute.PSI_OUTPUT_PATH);
+      // The cached resolution already applies the parser-class-package fallback, so
+      // path(PARSER_OUTPUT_PATH) is non-null whenever the legacy code would have
+      // produced a parser target. The only thing left is to materialize each Path
+      // as a VirtualFile, creating the directory if it doesn't yet exist on disk.
+      BnfPathsResolution paths = BnfPaths.resolve(bnf);
+      VirtualFile target             = ensureDirectory(paths.path(KnownAttribute.PARSER_OUTPUT_PATH));
+      VirtualFile psiTarget          = ensureDirectory(paths.path(KnownAttribute.PSI_OUTPUT_PATH));
+      VirtualFile etHolderTarget     = ensureDirectory(paths.path(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
+      VirtualFile syntaxHolderTarget = ensureDirectory(paths.path(KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
+      VirtualFile converterTarget    = ensureDirectory(paths.path(KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH));
 
-      VirtualFile psiTarget =
-        psiOutput.isEmpty() ? null : FileGeneratorUtil.getTargetDirectoryRelativeToContentRoot(file, project, psiOutput, "", true);
       rootMap.put(file, target);
       psiRootMap.put(file, psiTarget);
-      packageMap.put(target, StringUtil.notNullize(packageIndex.getPackageNameByDirectory(target)));
+      etHolderMap.put(file, etHolderTarget);
+      syntaxHolderMap.put(file, syntaxHolderTarget);
+      converterMap.put(file, converterTarget);
+      packageMap.put(target, StringUtil.notNullize(target != null ? packageIndex.getPackageNameByDirectory(target) : null));
     }
-    return new BatchGenerationContext(project, bnfFiles, rootMap, psiRootMap, packageMap);
+    return new BatchGenerationContext(project, bnfFiles, rootMap, psiRootMap,
+                                      etHolderMap, syntaxHolderMap, converterMap, packageMap);
   }
+
+  private static @Nullable VirtualFile ensureDirectory(@Nullable Path absolutePath) {
+    if (absolutePath == null) return null;
+    try {
+      return com.intellij.openapi.vfs.VfsUtil.createDirectoryIfMissing(absolutePath.toString());
+    }
+    catch (IOException ex) {
+      return null;
+    }
+  }
+
 }

--- a/generator/src/org/intellij/grammar/generator/batch/FileGeneratorUtil.java
+++ b/generator/src/org/intellij/grammar/generator/batch/FileGeneratorUtil.java
@@ -10,76 +10,39 @@ import com.intellij.notification.Notifications;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.FileIndex;
-import com.intellij.openapi.roots.PackageIndex;
-import com.intellij.openapi.roots.ProjectFileIndex;
-import com.intellij.openapi.roots.ProjectRootManager;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.vfs.VirtualFileUtil;
-import com.intellij.psi.search.FilenameIndex;
-import com.intellij.psi.search.ProjectScope;
-import org.intellij.grammar.BnfFileType;
-import org.intellij.grammar.config.Options;
+import org.intellij.grammar.BnfPaths;
 import org.intellij.grammar.generator.CommonBnfConstants;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-
-import static com.intellij.util.ArrayUtil.getFirstElement;
+import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * @author gregsh
  */
 public class FileGeneratorUtil {
   /**
-   * Resolves the output directory for a file to be generated.
+   * Resolves the output directory for a file to be generated. Wraps the read-only inference in
+   * {@link BnfPaths#inferTargetDirectory} with the create step: the inferred path is realized
+   * on disk via {@link VfsUtil#createDirectoryIfMissing(String)} inside a write action.
    *
-   * <p>The resolution follows these steps:
-   * <ol>
-   *   <li><b>Anchor on an existing file.</b> If {@code targetFile} is provided, the project index
-   *       is searched for a file with that name. Candidates are ranked by preferring source roots
-   *       over content roots, then by shorter path. The first candidate whose parent directory
-   *       belongs to {@code targetPackage} (or any directory if {@code targetPackage} is empty)
-   *       is used as the anchor. Its source/content root becomes the base for generation.</li>
-   *   <li><b>Fall back to the source file's root.</b> If no existing file is found, the root is
-   *       derived from {@code sourceFile}:
-   *       <ul>
-   *         <li>For {@code .bnf} and {@code .jflex} files the content root is preferred, because
-   *             generated sources are expected to land in a separate "gen" subtree rather than
-   *             next to the grammar.</li>
-   *         <li>For other file types with a non-empty {@code targetPackage} the source root of
-   *             {@code sourceFile} is preferred.</li>
-   *         <li>If neither applies, the first available content root is used.</li>
-   *       </ul>
-   *   </li>
-   *   <li><b>Append the package path.</b> Inside the resolved root, subdirectories matching
-   *       {@code targetPackage} are created if absent. When the root is not already a registered
-   *       source root (i.e., the "gen" root scenario), the configured {@link Options#GEN_DIR}
-   *       folder is prepended to the path.</li>
-   * </ol>
+   * <p>Throws {@link ProcessCanceledException} (after showing an error notification) when no
+   * suitable root can be guessed or directory creation fails.
    *
    * @param project       the current project
-   * @param sourceFile    the grammar or source file that triggers generation; used to locate a
-   *                      fallback root when no existing target file is found
+   * @param sourceFile    the grammar or source file that triggers generation
    * @param targetFile    short file name (without path) to look up in the project index as an
    *                      anchor; may be {@code null} to skip the lookup
-   * @param targetPackage fully qualified package name for the generated file (e.g.
-   *                      {@code "com.example.psi"}); may be {@code null} or empty when the file
-   *                      should go directly into the root directory
-   * @param returnRoot    if {@code true}, returns the generation root directory (the source root
-   *                      or the {@link Options#GEN_DIR} child of the content root) rather than
-   *                      the deepest package subdirectory
+   * @param targetPackage fully qualified package name for the generated file
+   * @param returnRoot    if {@code true}, returns the generation root rather than the deepest
+   *                      package subdirectory
+   * @param preferGenRoot if {@code true}, prefer a content-root + {@code gen} layout over the
+   *                      source root of {@code sourceFile}
    * @return the {@link VirtualFile} directory where the generated file should be written;
    *         created if it does not exist yet
-   * @throws ProcessCanceledException if no suitable root can be determined, or if directory
-   *                                  creation fails; an error notification is shown to the user
    */
   public static @NotNull VirtualFile getTargetDirectoryFor(@NotNull Project project,
                                                            @NotNull VirtualFile sourceFile,
@@ -88,31 +51,27 @@ public class FileGeneratorUtil {
                                                            boolean returnRoot,
                                                            boolean preferGenRoot
   ) {
-    boolean hasPackage = StringUtil.isNotEmpty(targetPackage);
-    ProjectRootManager rootManager = ProjectRootManager.getInstance(project);
-    PackageIndex packageIndex = PackageIndex.getInstance(project);
-    ProjectFileIndex fileIndex = ProjectFileIndex.getInstance(project);
-
-    VirtualFile existingFile = findExistingFile(project, targetFile, targetPackage, fileIndex, packageIndex);
-
-    VirtualFile existingFileRoot =
-      existingFile == null ? null :
-      fileIndex.isInSourceContent(existingFile) ? fileIndex.getSourceRootForFile(existingFile) :
-      fileIndex.isInContent(existingFile) ? fileIndex.getContentRootForFile(existingFile) : null;
-
-    boolean preferSourceRoot = hasPackage && !preferGenRoot;
-    VirtualFile[] sourceRoots = rootManager.getContentSourceRoots();
-    VirtualFile[] contentRoots = rootManager.getContentRoots();
-    VirtualFile virtualRoot = existingFileRoot != null ? existingFileRoot :
-                                    preferSourceRoot && fileIndex.isInSource(sourceFile) ? fileIndex.getSourceRootForFile(sourceFile) :
-                                    fileIndex.isInContent(sourceFile) ? fileIndex.getContentRootForFile(sourceFile) :
-                                    getFirstElement(preferSourceRoot && sourceRoots.length > 0? sourceRoots : contentRoots);
-    if (virtualRoot == null) {
+    Path inferred = BnfPaths.inferTargetDirectory(project, sourceFile, targetFile, targetPackage, returnRoot, preferGenRoot);
+    if (inferred == null) {
       fail(project, sourceFile, "Unable to guess target source root");
       throw new ProcessCanceledException();
     }
+
     try {
-      return createOutputDirectory(virtualRoot, targetPackage, packageIndex, fileIndex, returnRoot);
+      VirtualFile result = WriteAction.computeAndWait(() -> {
+        try {
+          return VfsUtil.createDirectoryIfMissing(inferred.toString());
+        }
+        catch (IOException ex) {
+          throw new RuntimeException(ex);
+        }
+      });
+      if (result != null) VfsUtil.markDirtyAndRefresh(false, true, true, result);
+      if (result == null) {
+        fail(project, sourceFile, "Cannot create directory: " + inferred);
+        throw new ProcessCanceledException();
+      }
+      return result;
     }
     catch (ProcessCanceledException ex) {
       throw ex;
@@ -120,81 +79,6 @@ public class FileGeneratorUtil {
     catch (Exception ex) {
       fail(project, sourceFile, ex.getMessage());
       throw new ProcessCanceledException();
-    }
-  }
-
-  private static @Nullable VirtualFile findExistingFile(@NotNull Project project,
-                                                        @Nullable String targetFile,
-                                                        @Nullable String targetPackage,
-                                                        ProjectFileIndex fileIndex,
-                                                        PackageIndex packageIndex) {
-    if (targetFile == null) {
-      return null;
-    }
-
-    Collection<VirtualFile> fromIndex = FilenameIndex.getVirtualFilesByName(targetFile, ProjectScope.getProjectScope(project));
-    List<VirtualFile> files = new ArrayList<>(fromIndex);
-    files.sort((f1, f2) -> {
-      boolean b1 = fileIndex.isInSource(f1);
-      boolean b2 = fileIndex.isInSource(f2);
-      if (b1 != b2) return b1 ? -1 : 1;
-      return Integer.compare(f1.getPath().length(), f2.getPath().length());
-    });
-
-    for (VirtualFile file : files) {
-      String existingFilePackage = packageIndex.getPackageNameByDirectory(file.getParent());
-      if (StringUtil.isEmpty(targetPackage) || existingFilePackage == null || targetPackage.equals(existingFilePackage)) {
-        return file;
-      }
-    }
-    return null;
-  }
-
-  public static @NotNull VirtualFile getTargetDirectoryRelativeToContentRoot(@NotNull VirtualFile bnfFile,
-                                                                             @NotNull Project project,
-                                                                             @NotNull String targetRelativePath,
-                                                                             @Nullable String targetPackage,
-                                                                             boolean returnRoot) {
-    PackageIndex packageIndex = PackageIndex.getInstance(project);
-    ProjectFileIndex fileIndex = ProjectRootManager.getInstance(project).getFileIndex();
-    VirtualFile basePath = fileIndex.getContentRootForFile(bnfFile);
-    if (basePath != null) {
-    try {
-      VirtualFile file = VirtualFileUtil.findOrCreateDirectory(basePath, targetRelativePath);
-      return createOutputDirectory(file, targetPackage, packageIndex, fileIndex, returnRoot);
-    }
-    catch (ProcessCanceledException ex) {
-      throw ex;
-    }
-    catch (Exception ex) {
-      fail(project, targetRelativePath, ex.getMessage());
-      throw new ProcessCanceledException();
-    }
-  }
-    fail(project, targetRelativePath, "Unable to find target source root");
-    throw new ProcessCanceledException();
-  }
-
-  private static VirtualFile createOutputDirectory(@NotNull VirtualFile virtualRoot,
-                                                   @Nullable String targetPackage,
-                                                   @NotNull PackageIndex packageIndex,
-                                                   @NotNull FileIndex fileIndex,
-                                                   boolean returnRoot) throws Exception {
-    boolean hasPackage = StringUtil.isNotEmpty(targetPackage);
-    String packagePrefix = StringUtil.notNullize(packageIndex.getPackageNameByDirectory(virtualRoot));
-    String genDirName = Options.GEN_DIR.get();
-    boolean newGenRoot = !fileIndex.isInSourceContent(virtualRoot);
-    String relativePath = (hasPackage && newGenRoot ? genDirName + "/" + targetPackage :
-                           hasPackage ? StringUtil.trimStart(StringUtil.trimStart(targetPackage, packagePrefix), ".") :
-                           newGenRoot ? genDirName : "").replace('.', '/');
-    if (relativePath.isEmpty()) {
-      return virtualRoot;
-    }
-    else {
-      VirtualFile result = WriteAction.compute(() -> VfsUtil.createDirectoryIfMissing(virtualRoot, relativePath));
-      VfsUtil.markDirtyAndRefresh(false, true, true, result);
-      return returnRoot && newGenRoot ? Objects.requireNonNull(virtualRoot.findChild(genDirName)) :
-             returnRoot ? virtualRoot : result;
     }
   }
 

--- a/resources/META-INF/plugin-java.xml
+++ b/resources/META-INF/plugin-java.xml
@@ -2,8 +2,7 @@
 <idea-plugin>
   <resource-bundle>messages.GrammarKitBundle</resource-bundle>
   <extensions defaultExtensionNs="com.intellij">
-    <projectService serviceInterface="org.intellij.grammar.java.JavaHelper"
-                    serviceImplementation="org.intellij.grammar.java.PsiHelper"/>
+    <projectService serviceImplementation="org.intellij.grammar.java.PsiHelperFactory"/>
     <referencesSearch implementation="org.intellij.jflex.psi.impl.JFlexStateUsageSearcher"/>
     <regExpLanguageHost forClass="org.intellij.grammar.psi.impl.BnfStringImpl"
                         implementationClass="org.intellij.grammar.psi.impl.BnfStringRegexHost"/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -28,6 +28,14 @@
     <lang.psiStructureViewFactory language="BNF" implementationClass="org.intellij.grammar.BnfStructureViewFactory"/>
     <codeInsight.lineMarkerProvider language="BNF" implementationClass="org.intellij.grammar.editor.BnfRuleLineMarkerProvider"/>
     <codeInsight.lineMarkerProvider language="BNF" implementationClass="org.intellij.grammar.editor.BnfRecursionLineMarkerProvider"/>
+    <codeInsight.declarativeInlayProvider language="BNF"
+                                          implementationClass="org.intellij.grammar.editor.BnfPathAttributeInlayHintsProvider"
+                                          isEnabledByDefault="true"
+                                          group="OTHER_GROUP"
+                                          providerId="bnf.path.attribute.resolved.location"
+                                          bundle="messages.GrammarKitBundle"
+                                          nameKey="inlay.bnf.path.attribute.name"
+                                          descriptionKey="inlay.bnf.path.attribute.description"/>
     <lang.commenter language="BNF" implementationClass="org.intellij.grammar.BnfCommenter"/>
     <completion.contributor language="BNF" implementationClass="org.intellij.grammar.BnfCompletionContributor" order="before javaClassName"/>
 

--- a/src/org/intellij/grammar/editor/BnfPathAttributeInlayHintsProvider.java
+++ b/src/org/intellij/grammar/editor/BnfPathAttributeInlayHintsProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2011-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+package org.intellij.grammar.editor;
+
+import com.intellij.codeInsight.hints.declarative.*;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import kotlin.Unit;
+import kotlin.jvm.functions.Function1;
+import org.intellij.grammar.BnfPaths;
+import org.intellij.grammar.psi.BnfAttr;
+import org.intellij.grammar.psi.BnfAttributes;
+import org.intellij.grammar.psi.BnfExpression;
+import org.intellij.grammar.psi.BnfFile;
+import org.intellij.grammar.psi.BnfStringLiteralExpression;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+
+/**
+ * Shows the absolute filesystem location that an {@code *InputPath} or {@code *OutputPath} BNF
+ * attribute resolves to. Path resolution is delegated to {@link BnfPaths}, which is the single
+ * source of truth for path-attribute resolution across the IDE and the build context.
+ */
+final class BnfPathAttributeInlayHintsProvider implements InlayHintsProvider, DumbAware {
+
+  private static final int MAX_SEGMENT_LENGTH = 30;
+
+  @Override
+  public @Nullable InlayHintsCollector createCollector(@NotNull PsiFile file, @NotNull Editor editor) {
+    return file instanceof BnfFile ? new Collector() : null;
+  }
+
+  private static final class Collector implements SharedBypassCollector {
+    @Override
+    public void collectFromElement(@NotNull PsiElement element, @NotNull InlayTreeSink sink) {
+      if (!(element instanceof BnfAttr attr)) return;
+      if (BnfPaths.pathAttributeByName(attr.getName()) == null) return;
+
+      BnfExpression expression = attr.getExpression();
+      if (!(expression instanceof BnfStringLiteralExpression literal)) return;
+
+      String value = BnfAttributes.getLiteralValue(literal);
+      if (value == null || value.isEmpty()) return;
+
+      Path resolved = BnfPaths.resolveOnDisk((BnfFile)attr.getContainingFile(), value);
+      if (resolved == null) return;
+
+      String absolute = resolved.toString();
+
+      int offset = literal.getTextRange().getEndOffset();
+      InlineInlayPosition position = new InlineInlayPosition(offset, true, 0);
+      Function1<PresentationTreeBuilder, Unit> builderF = builder -> {
+        // Inline declarative hints truncate each text node to 30 chars
+        // (PresentationTreeBuilderImpl.MAX_SEGMENT_TEXT_LENGTH); split into chunks to keep the
+        // whole path visible.
+        for (int i = 0; i < absolute.length(); i += MAX_SEGMENT_LENGTH) {
+          builder.text(absolute.substring(i, Math.min(i + MAX_SEGMENT_LENGTH, absolute.length())), null);
+        }
+        return Unit.INSTANCE;
+      };
+      sink.addPresentation(position, null, null, true, builderF);
+    }
+  }
+}

--- a/testData/kotlin/PsiGen.PSI.expected.kt
+++ b/testData/kotlin/PsiGen.PSI.expected.kt
@@ -1,4 +1,4 @@
-// ---- generated/GeneratedSyntaxElementTypes.kt -----------------
+// ---- ../myPsi/output/generated/GeneratedSyntaxElementTypes.kt -----------------
 //header.txt
 package generated
 

--- a/testData/kotlin/SelfBnf.PSI.expected.kt
+++ b/testData/kotlin/SelfBnf.PSI.expected.kt
@@ -1,4 +1,4 @@
-// ---- org/intellij/grammar/BnfSyntaxTypes.kt -----------------
+// ---- ../grammar-kit/psi/org/intellij/grammar/BnfSyntaxTypes.kt -----------------
 // license.txt
 package org.intellij.grammar
 

--- a/testData/kotlin/SelfFlex.PSI.expected.kt
+++ b/testData/kotlin/SelfFlex.PSI.expected.kt
@@ -1,4 +1,4 @@
-// ---- org/intellij/jflex/JFlexTypes.kt -----------------
+// ---- ../grammar-kit/psi/org/intellij/jflex/JFlexTypes.kt -----------------
 // license.txt
 package org.intellij.jflex
 

--- a/testData/kotlin/Stub.PSI.expected.kt
+++ b/testData/kotlin/Stub.PSI.expected.kt
@@ -1,4 +1,4 @@
-// ---- test/FooSyntaxTypes.kt -----------------
+// ---- ../myPsi/output/test/FooSyntaxTypes.kt -----------------
 //header.txt
 package test
 

--- a/tests/org/intellij/grammar/BnfGeneratorPsiTest.java
+++ b/tests/org/intellij/grammar/BnfGeneratorPsiTest.java
@@ -11,6 +11,7 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import com.intellij.util.ProcessingContext;
 import org.intellij.grammar.generator.JavaParserGenerator;
+import org.intellij.grammar.KnownAttribute;
 import org.intellij.grammar.generator.NameShortener;
 import org.intellij.grammar.generator.OutputOpener;
 import org.intellij.grammar.java.JavaHelper;
@@ -230,14 +231,15 @@ public class BnfGeneratorPsiTest extends BasePlatformTestCase {
       }
       return OutputOpener.DEFAULT.openOutput(className, file, myBnfFile);
     };
-    JavaParserGenerator generator = new JavaParserGenerator(bnfFile, "", FileUtilRt.getTempDirectory(), "", outputOpener);
+    JavaParserGenerator generator = new JavaParserGenerator(bnfFile, "", "", outputOpener,
+      BnfPaths.resolveExplicit(java.util.Map.of(KnownAttribute.PARSER_OUTPUT_PATH, java.nio.file.Path.of(FileUtilRt.getTempDirectory()))));
 
     // Simulate PsiHelper bug for qualified types (#436):
     // In real IDE with platform SDK classes resolved from bytecode,
     // PsiHelper.getAnnotationsInner() fails to filter @NotNull from method annotations
     // when PsiType.getAnnotations() doesn't return annotations on inner type components
     // of qualified types. We simulate this by wrapping the JavaHelper.
-    Field javaHelperField = JavaParserGenerator.class.getDeclaredField("myJavaHelper");
+    Field javaHelperField = JavaParserGenerator.class.getSuperclass().getDeclaredField("myJavaHelper");
     javaHelperField.setAccessible(true);
     JavaHelper original = (JavaHelper) javaHelperField.get(generator);
     javaHelperField.set(generator, new DuplicateAnnotationJavaHelper(original));

--- a/tests/org/intellij/grammar/BnfPathsResolutionTest.java
+++ b/tests/org/intellij/grammar/BnfPathsResolutionTest.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 /**
  * Exhaustive coverage of {@link BnfPaths#resolve} and {@link BnfPathsResolution} — the cached
- * single source of truth for {@code *OutputPath} resolution.
+ * single source of truth for {@code *InputPath} / {@code *OutputPath} resolution.
  */
 public class BnfPathsResolutionTest extends JavaCodeInsightFixtureTestCase {
 
@@ -30,6 +30,20 @@ public class BnfPathsResolutionTest extends JavaCodeInsightFixtureTestCase {
   }
 
   // ---- Direct path lookup ---------------------------------------------------
+
+  public void testEachInputPathReturnsAbsoluteResolved() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      {
+        inputPath="../in"
+        psiInputPath="../psi-in"
+      }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    Path parent = bnfParent(bnf);
+    assertEquals(parent.resolve("../in").normalize(), paths.path(KnownAttribute.INPUT_PATH));
+    assertEquals(parent.resolve("../psi-in").normalize(), paths.path(KnownAttribute.PSI_INPUT_PATH));
+  }
 
   public void testEachOutputPathReturnsAbsoluteResolved() {
     BnfFile bnf = bnfWith("g.bnf", """
@@ -52,10 +66,31 @@ public class BnfPathsResolutionTest extends JavaCodeInsightFixtureTestCase {
     assertEquals(parent.resolve("../conv").normalize(),    paths.path(KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH));
   }
 
-  public void testRelativePathsAreNormalized() {
-    BnfFile bnf = bnfWith("g.bnf", "{ parserOutputPath=\"./a/../b\" }\nroot ::= 'a'");
+  public void testInputPathDefaultsToBnfParent() {
+    BnfFile bnf = bnfWith("g.bnf", "{ parserClass=\"com.example.P\" }\nroot ::= 'a'");
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
     Path parent = bnfParent(bnf);
-    assertEquals(parent.resolve("b").normalize(), BnfPaths.resolve(bnf).path(KnownAttribute.PARSER_OUTPUT_PATH));
+    // Unset inputPath defaults to the BNF file's parent directory; the input cascade then fills
+    // psiInputPath from the global default.
+    assertEquals(parent, paths.path(KnownAttribute.INPUT_PATH));
+    assertEquals(parent, paths.path(KnownAttribute.PSI_INPUT_PATH));
+  }
+
+  public void testEmptyStringTreatedAsUnset() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      { parserOutputPath="" inputPath="" }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    // The empty string is treated as unset; "unset" now resolves to the BNF parent default.
+    assertEquals(bnfParent(bnf), paths.path(KnownAttribute.INPUT_PATH));
+    // PARSER_OUTPUT_PATH may be filled in by the fallback (parserClass package), but never by ""
+  }
+
+  public void testRelativePathsAreNormalized() {
+    BnfFile bnf = bnfWith("g.bnf", "{ inputPath=\"./a/../b\" }\nroot ::= 'a'");
+    Path parent = bnfParent(bnf);
+    assertEquals(parent.resolve("b").normalize(), BnfPaths.resolve(bnf).path(KnownAttribute.INPUT_PATH));
   }
 
   // ---- Output-path fallback chain ------------------------------------------
@@ -127,41 +162,133 @@ public class BnfPathsResolutionTest extends JavaCodeInsightFixtureTestCase {
                   paths.path(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
   }
 
+  // ---- referencePath cascade ----------------------------------------------
+
+  public void testReferencePathPrefersSpecificInputOverGlobal() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      { inputPath="../global" psiInputPath="../psi" }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    Path parent = bnfParent(bnf);
+    // mixin / implements / psiImplUtilClass all share psiInputPath now; parserUtilClass keeps
+    // falling through to the global inputPath.
+    assertEquals(parent.resolve("../psi").normalize(), BnfPaths.referencePath(paths, KnownAttribute.MIXIN));
+    assertEquals(parent.resolve("../psi").normalize(), BnfPaths.referencePath(paths, KnownAttribute.IMPLEMENTS));
+    assertEquals(parent.resolve("../psi").normalize(), BnfPaths.referencePath(paths, KnownAttribute.PSI_IMPL_UTIL_CLASS));
+    assertEquals(parent.resolve("../global").normalize(), BnfPaths.referencePath(paths, KnownAttribute.PARSER_UTIL_CLASS));
+  }
+
+  public void testReferencePathFallsBackToGlobalInputPath() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      { inputPath="../global" }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    Path parent = bnfParent(bnf);
+    assertEquals(parent.resolve("../global").normalize(), BnfPaths.referencePath(paths, KnownAttribute.MIXIN));
+    assertEquals(parent.resolve("../global").normalize(), BnfPaths.referencePath(paths, KnownAttribute.PARSER_UTIL_CLASS));
+    assertEquals(parent.resolve("../global").normalize(), BnfPaths.referencePath(paths, KnownAttribute.IMPLEMENTS));
+  }
+
+  public void testReferencePathFallsBackToBnfParentInIdeContext() {
+    BnfFile bnf = bnfWith("g.bnf", "{ parserClass=\"com.example.P\" }\nroot ::= 'a'");
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    Path parent = bnfParent(bnf);
+    // BnfPaths.compute() seeds INPUT_PATH = BNF parent when nothing is set, so referencePath
+    // never returns null for an IDE-resolved file.
+    assertEquals(parent, BnfPaths.referencePath(paths, KnownAttribute.MIXIN));
+    assertEquals(parent, BnfPaths.referencePath(paths, KnownAttribute.IMPLEMENTS));
+  }
+
+  public void testReferencePathOutputAttributeUsesOutputPath() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      { parserOutputPath="../parser" inputPath="../in" }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    Path parent = bnfParent(bnf);
+    // parserClass → parserOutputPath, NOT global inputPath
+    assertEquals(parent.resolve("../parser").normalize(), BnfPaths.referencePath(paths, KnownAttribute.PARSER_CLASS));
+  }
+
+  public void testReferencePathOutputDoesNotFallBackToInputPath() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      { inputPath="../in" parserClass="com.example.P" }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    // parserOutputPath is unset; the parserClass-package fallback may produce a value, but
+    // critically referencePath(parserClass) must NOT return inputPath.
+    Path ref = BnfPaths.referencePath(paths, KnownAttribute.PARSER_CLASS);
+    Path globalInput = paths.path(KnownAttribute.INPUT_PATH);
+    if (ref != null && globalInput != null) {
+      assertFalse("referencePath(parserClass) must not fall back to inputPath",
+                  globalInput.equals(ref));
+    }
+  }
+
+  public void testReferencePathFqnNotInAnyMapFallsBackToGlobalInputPath() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      { inputPath="../global" }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    Path parent = bnfParent(bnf);
+    // psiTreeUtilClass has no entry in INPUT_FOR or OUTPUT_FOR — falls through to inputPath.
+    assertEquals(parent.resolve("../global").normalize(),
+                 BnfPaths.referencePath(paths, KnownAttribute.PSI_TREE_UTIL_CLASS));
+  }
+
+  public void testReferencePathNullArgFallsBackToGlobalInputPath() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      { inputPath="../global" }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    Path parent = bnfParent(bnf);
+    assertEquals(parent.resolve("../global").normalize(), BnfPaths.referencePath(paths, null));
+  }
+
   // ---- Caching -------------------------------------------------------------
 
   public void testRepeatedResolveReturnsSameInstance() {
-    BnfFile bnf = bnfWith("g.bnf", "{ parserOutputPath=\"../x\" }\nroot ::= 'a'");
+    BnfFile bnf = bnfWith("g.bnf", "{ inputPath=\"../x\" }\nroot ::= 'a'");
     BnfPathsResolution a = BnfPaths.resolve(bnf);
     BnfPathsResolution b = BnfPaths.resolve(bnf);
     assertSame(a, b);
   }
 
   public void testDifferentBnfFilesGetIndependentResolutions() {
-    BnfFile a = bnfWith("a.bnf", "{ parserOutputPath=\"../a-out\" }\nroot ::= 'x'");
+    BnfFile a = bnfWith("a.bnf", "{ inputPath=\"../a-in\" }\nroot ::= 'x'");
     Path aParent = bnfParent(a);
     BnfPathsResolution aPaths = BnfPaths.resolve(a);
-    assertEquals(aParent.resolve("../a-out").normalize(), aPaths.path(KnownAttribute.PARSER_OUTPUT_PATH));
+    assertEquals(aParent.resolve("../a-in").normalize(), aPaths.path(KnownAttribute.INPUT_PATH));
     // configureByText replaces the previous fixture file, so we re-fetch the parent for the new BNF.
-    BnfFile b = bnfWith("b.bnf", "{ parserOutputPath=\"../b-out\" }\nroot ::= 'x'");
+    BnfFile b = bnfWith("b.bnf", "{ inputPath=\"../b-in\" }\nroot ::= 'x'");
     Path bParent = bnfParent(b);
     BnfPathsResolution bPaths = BnfPaths.resolve(b);
-    assertEquals(bParent.resolve("../b-out").normalize(), bPaths.path(KnownAttribute.PARSER_OUTPUT_PATH));
+    assertEquals(bParent.resolve("../b-in").normalize(), bPaths.path(KnownAttribute.INPUT_PATH));
     assertNotSame(aPaths, bPaths);
   }
 
   // ---- Construction from explicit map (test fixtures + Main.java path) ----
 
   public void testEmptyResolutionExposesNoPaths() {
+    assertNull(BnfPathsResolution.EMPTY.path(KnownAttribute.INPUT_PATH));
     assertNull(BnfPathsResolution.EMPTY.path(KnownAttribute.PARSER_OUTPUT_PATH));
-    assertNull(BnfPathsResolution.EMPTY.path(KnownAttribute.PSI_OUTPUT_PATH));
+    assertNull(BnfPaths.referencePath(BnfPathsResolution.EMPTY, KnownAttribute.MIXIN));
+    assertNull(BnfPaths.referencePath(BnfPathsResolution.EMPTY, null));
   }
 
   public void testResolveExplicitFromMap() {
     Map<KnownAttribute<String>, Path> map = new HashMap<>();
     map.put(KnownAttribute.PARSER_OUTPUT_PATH, Path.of("/tmp/parser"));
+    map.put(KnownAttribute.PSI_INPUT_PATH, Path.of("/tmp/psi-in"));
     BnfPathsResolution paths = BnfPaths.resolveExplicit(map);
 
     assertEquals(Path.of("/tmp/parser"), paths.path(KnownAttribute.PARSER_OUTPUT_PATH));
+    assertEquals(Path.of("/tmp/psi-in"), paths.path(KnownAttribute.PSI_INPUT_PATH));
     // BnfPaths.resolveExplicit applies the output cascade — psi falls back to parser.
     assertEquals(Path.of("/tmp/parser"), paths.path(KnownAttribute.PSI_OUTPUT_PATH));
   }
@@ -197,12 +324,14 @@ public class BnfPathsResolutionTest extends JavaCodeInsightFixtureTestCase {
   }
 
   public void testPathStringThrowsWhenAttributeUnresolved() {
+    BnfPathsResolution paths = BnfPaths.resolveExplicit(
+      Map.of(KnownAttribute.PARSER_OUTPUT_PATH, Path.of("/tmp/parser")));
     try {
-      BnfPathsResolution.EMPTY.pathString(KnownAttribute.PSI_OUTPUT_PATH);
-      fail("expected IllegalStateException for unset output attribute");
+      paths.pathString(KnownAttribute.PSI_INPUT_PATH);
+      fail("expected IllegalStateException for unset input attribute");
     }
     catch (IllegalStateException expected) {
-      assertTrue(expected.getMessage().contains("psiOutputPath"));
+      assertTrue(expected.getMessage().contains("psiInputPath"));
     }
   }
 
@@ -218,20 +347,55 @@ public class BnfPathsResolutionTest extends JavaCodeInsightFixtureTestCase {
 
   // ---- Negative / malformed input -----------------------------------------
 
-  public void testEmptyOutputPathTreatedAsUnset() {
-    BnfFile bnf = bnfWith("g.bnf", "{ parserOutputPath=\"\" }\nroot ::= 'a'");
-    // PARSER_OUTPUT_PATH may be filled in by the parserClass-package fallback, but never by "".
-    Path resolved = BnfPaths.resolve(bnf).path(KnownAttribute.PARSER_OUTPUT_PATH);
-    if (resolved != null) {
-      assertFalse("empty string must not become a resolved path",
-                  resolved.toString().equals(bnfParent(bnf).toString() + "/"));
-    }
+  public void testEmptyInputPathTreatedAsUnset() {
+    BnfFile bnf = bnfWith("g.bnf", "{ inputPath=\"\" }\nroot ::= 'a'");
+    // Empty string is still "unset"; the unset fallback resolves to the BNF file's parent.
+    assertEquals(bnfParent(bnf), BnfPaths.resolve(bnf).path(KnownAttribute.INPUT_PATH));
+  }
+
+  public void testDotResolvesToBnfParent() {
+    BnfFile bnf = bnfWith("g.bnf", "{ inputPath=\".\" }\nroot ::= 'a'");
+    Path parent = bnfParent(bnf);
+    assertEquals(parent.normalize(), BnfPaths.resolve(bnf).path(KnownAttribute.INPUT_PATH));
   }
 
   public void testManyDoubleDotsEscapeProjectRoot() {
-    BnfFile bnf = bnfWith("g.bnf", "{ parserOutputPath=\"../../../../../../tmp\" }\nroot ::= 'a'");
+    BnfFile bnf = bnfWith("g.bnf", "{ inputPath=\"../../../../../../tmp\" }\nroot ::= 'a'");
     Path parent = bnfParent(bnf);
     Path expected = parent.resolve("../../../../../../tmp").normalize();
-    assertEquals(expected, BnfPaths.resolve(bnf).path(KnownAttribute.PARSER_OUTPUT_PATH));
+    assertEquals(expected, BnfPaths.resolve(bnf).path(KnownAttribute.INPUT_PATH));
+  }
+
+  // ---- Input cascade -------------------------------------------------------
+
+  public void testInputCascadeFillsPsiInputFromGlobal() {
+    Map<KnownAttribute<String>, Path> map = new HashMap<>();
+    map.put(KnownAttribute.INPUT_PATH, Path.of("/tmp/in"));
+    BnfPathsResolution paths = BnfPaths.resolveExplicit(map);
+    assertEquals(Path.of("/tmp/in"), paths.path(KnownAttribute.PSI_INPUT_PATH));
+  }
+
+  public void testInputCascadePreservesExplicitOverrides() {
+    Map<KnownAttribute<String>, Path> map = new HashMap<>();
+    map.put(KnownAttribute.INPUT_PATH, Path.of("/tmp/in"));
+    map.put(KnownAttribute.PSI_INPUT_PATH, Path.of("/tmp/psi-in"));
+    BnfPathsResolution paths = BnfPaths.resolveExplicit(map);
+    assertEquals(Path.of("/tmp/psi-in"), paths.path(KnownAttribute.PSI_INPUT_PATH));
+    assertEquals(Path.of("/tmp/in"), paths.path(KnownAttribute.INPUT_PATH));
+  }
+
+  public void testResolveExplicitWithBnfParentDefaultsInputPath() {
+    Path bnfParent = Path.of("/tmp/grammar");
+    BnfPathsResolution paths = BnfPaths.resolveExplicit(Map.of(), bnfParent);
+    assertEquals(bnfParent, paths.path(KnownAttribute.INPUT_PATH));
+    assertEquals(bnfParent, paths.path(KnownAttribute.PSI_INPUT_PATH));
+  }
+
+  public void testResolveExplicitWithBnfParentRespectsExplicitInput() {
+    Map<KnownAttribute<String>, Path> map = new HashMap<>();
+    map.put(KnownAttribute.INPUT_PATH, Path.of("/tmp/explicit-in"));
+    BnfPathsResolution paths = BnfPaths.resolveExplicit(map, Path.of("/tmp/grammar"));
+    assertEquals(Path.of("/tmp/explicit-in"), paths.path(KnownAttribute.INPUT_PATH));
+    assertEquals(Path.of("/tmp/explicit-in"), paths.path(KnownAttribute.PSI_INPUT_PATH));
   }
 }

--- a/tests/org/intellij/grammar/BnfPathsResolutionTest.java
+++ b/tests/org/intellij/grammar/BnfPathsResolutionTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2011-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+package org.intellij.grammar;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase;
+import org.intellij.grammar.psi.BnfFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Exhaustive coverage of {@link BnfPaths#resolve} and {@link BnfPathsResolution} — the cached
+ * single source of truth for {@code *OutputPath} resolution.
+ */
+public class BnfPathsResolutionTest extends JavaCodeInsightFixtureTestCase {
+
+  /** Build a BNF file in the test fixture and return its parsed BnfFile. */
+  private @NotNull BnfFile bnfWith(@NotNull String name, @NotNull String content) {
+    return (BnfFile)myFixture.configureByText(name, content);
+  }
+
+  private @NotNull Path bnfParent(@NotNull BnfFile bnfFile) {
+    VirtualFile vf = bnfFile.getOriginalFile().getVirtualFile();
+    assertNotNull("BnfFile has no VFS file", vf);
+    return Path.of(vf.getParent().getPath());
+  }
+
+  // ---- Direct path lookup ---------------------------------------------------
+
+  public void testEachOutputPathReturnsAbsoluteResolved() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      {
+        parserClass="com.example.MyParser"
+        parserOutputPath="../parser"
+        psiOutputPath="../psi"
+        elementTypeHolderOutputPath="../et"
+        syntaxElementTypeHolderOutputPath="../syntax"
+        elementTypeConverterFactoryOutputPath="../conv"
+      }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    Path parent = bnfParent(bnf);
+    assertEquals(parent.resolve("../parser").normalize(),  paths.path(KnownAttribute.PARSER_OUTPUT_PATH));
+    assertEquals(parent.resolve("../psi").normalize(),     paths.path(KnownAttribute.PSI_OUTPUT_PATH));
+    assertEquals(parent.resolve("../et").normalize(),      paths.path(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
+    assertEquals(parent.resolve("../syntax").normalize(),  paths.path(KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
+    assertEquals(parent.resolve("../conv").normalize(),    paths.path(KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH));
+  }
+
+  public void testRelativePathsAreNormalized() {
+    BnfFile bnf = bnfWith("g.bnf", "{ parserOutputPath=\"./a/../b\" }\nroot ::= 'a'");
+    Path parent = bnfParent(bnf);
+    assertEquals(parent.resolve("b").normalize(), BnfPaths.resolve(bnf).path(KnownAttribute.PARSER_OUTPUT_PATH));
+  }
+
+  // ---- Output-path fallback chain ------------------------------------------
+
+  public void testPsiOutputFallsBackToParserOutput() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      { parserOutputPath="../parser" }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    assertEquals(paths.path(KnownAttribute.PARSER_OUTPUT_PATH),
+                 paths.path(KnownAttribute.PSI_OUTPUT_PATH));
+  }
+
+  public void testEtHolderFallsBackToParserOutputWhenPsiUnset() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      { parserOutputPath="../parser" }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    assertEquals(paths.path(KnownAttribute.PARSER_OUTPUT_PATH),
+                 paths.path(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
+  }
+
+  public void testEtHolderFallsBackToPsiOutputWhenPsiSet() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      { parserOutputPath="../parser" psiOutputPath="../psi" }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    // Element-type artifacts travel with PSI rather than the parser.
+    assertEquals(paths.path(KnownAttribute.PSI_OUTPUT_PATH),
+                 paths.path(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
+  }
+
+  public void testSyntaxHolderFallsBackToPsiOutput() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      { parserOutputPath="../parser" psiOutputPath="../psi" }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    assertEquals(paths.path(KnownAttribute.PSI_OUTPUT_PATH),
+                 paths.path(KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
+  }
+
+  public void testConverterFallsBackToPsiOutput() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      { parserOutputPath="../parser" psiOutputPath="../psi" }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    assertEquals(paths.path(KnownAttribute.PSI_OUTPUT_PATH),
+                 paths.path(KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH));
+  }
+
+  public void testExplicitOverridesShadowFallbacks() {
+    BnfFile bnf = bnfWith("g.bnf", """
+      {
+        parserOutputPath="../parser"
+        psiOutputPath="../psi"
+        elementTypeHolderOutputPath="../et"
+      }
+      root ::= 'a'
+      """);
+    BnfPathsResolution paths = BnfPaths.resolve(bnf);
+    Path parent = bnfParent(bnf);
+    assertEquals(parent.resolve("../et").normalize(), paths.path(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
+    assertNotSame(paths.path(KnownAttribute.PARSER_OUTPUT_PATH),
+                  paths.path(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
+  }
+
+  // ---- Caching -------------------------------------------------------------
+
+  public void testRepeatedResolveReturnsSameInstance() {
+    BnfFile bnf = bnfWith("g.bnf", "{ parserOutputPath=\"../x\" }\nroot ::= 'a'");
+    BnfPathsResolution a = BnfPaths.resolve(bnf);
+    BnfPathsResolution b = BnfPaths.resolve(bnf);
+    assertSame(a, b);
+  }
+
+  public void testDifferentBnfFilesGetIndependentResolutions() {
+    BnfFile a = bnfWith("a.bnf", "{ parserOutputPath=\"../a-out\" }\nroot ::= 'x'");
+    Path aParent = bnfParent(a);
+    BnfPathsResolution aPaths = BnfPaths.resolve(a);
+    assertEquals(aParent.resolve("../a-out").normalize(), aPaths.path(KnownAttribute.PARSER_OUTPUT_PATH));
+    // configureByText replaces the previous fixture file, so we re-fetch the parent for the new BNF.
+    BnfFile b = bnfWith("b.bnf", "{ parserOutputPath=\"../b-out\" }\nroot ::= 'x'");
+    Path bParent = bnfParent(b);
+    BnfPathsResolution bPaths = BnfPaths.resolve(b);
+    assertEquals(bParent.resolve("../b-out").normalize(), bPaths.path(KnownAttribute.PARSER_OUTPUT_PATH));
+    assertNotSame(aPaths, bPaths);
+  }
+
+  // ---- Construction from explicit map (test fixtures + Main.java path) ----
+
+  public void testEmptyResolutionExposesNoPaths() {
+    assertNull(BnfPathsResolution.EMPTY.path(KnownAttribute.PARSER_OUTPUT_PATH));
+    assertNull(BnfPathsResolution.EMPTY.path(KnownAttribute.PSI_OUTPUT_PATH));
+  }
+
+  public void testResolveExplicitFromMap() {
+    Map<KnownAttribute<String>, Path> map = new HashMap<>();
+    map.put(KnownAttribute.PARSER_OUTPUT_PATH, Path.of("/tmp/parser"));
+    BnfPathsResolution paths = BnfPaths.resolveExplicit(map);
+
+    assertEquals(Path.of("/tmp/parser"), paths.path(KnownAttribute.PARSER_OUTPUT_PATH));
+    // BnfPaths.resolveExplicit applies the output cascade — psi falls back to parser.
+    assertEquals(Path.of("/tmp/parser"), paths.path(KnownAttribute.PSI_OUTPUT_PATH));
+  }
+
+  public void testEveryOutputAttributeCascadesToParserWhenPsiUnset() {
+    BnfPathsResolution paths = BnfPaths.resolveExplicit(
+      Map.of(KnownAttribute.PARSER_OUTPUT_PATH, Path.of("/tmp/parser")));
+    // No PSI override: the cascade collapses to parser for every dependent attribute.
+    assertEquals(Path.of("/tmp/parser"), paths.path(KnownAttribute.PSI_OUTPUT_PATH));
+    assertEquals(Path.of("/tmp/parser"), paths.path(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
+    assertEquals(Path.of("/tmp/parser"), paths.path(KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
+    assertEquals(Path.of("/tmp/parser"), paths.path(KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH));
+  }
+
+  public void testEtAttributesCascadeToPsiWhenPsiSet() {
+    Map<KnownAttribute<String>, Path> map = new HashMap<>();
+    map.put(KnownAttribute.PARSER_OUTPUT_PATH, Path.of("/tmp/parser"));
+    map.put(KnownAttribute.PSI_OUTPUT_PATH, Path.of("/tmp/psi"));
+    BnfPathsResolution paths = BnfPaths.resolveExplicit(map);
+    // Element-type artifacts travel with PSI, not the parser, when PSI has its own root.
+    assertEquals(Path.of("/tmp/psi"), paths.path(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
+    assertEquals(Path.of("/tmp/psi"), paths.path(KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH));
+    assertEquals(Path.of("/tmp/psi"), paths.path(KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH));
+  }
+
+  public void testPathStringReturnsExplicitValue() {
+    Map<KnownAttribute<String>, Path> map = new HashMap<>();
+    map.put(KnownAttribute.PARSER_OUTPUT_PATH, Path.of("/tmp/parser"));
+    map.put(KnownAttribute.PSI_OUTPUT_PATH, Path.of("/tmp/psi"));
+    BnfPathsResolution paths = BnfPaths.resolveExplicit(map);
+    assertEquals("/tmp/psi", paths.pathString(KnownAttribute.PSI_OUTPUT_PATH));
+    assertEquals("/tmp/parser", paths.pathString(KnownAttribute.PARSER_OUTPUT_PATH));
+  }
+
+  public void testPathStringThrowsWhenAttributeUnresolved() {
+    try {
+      BnfPathsResolution.EMPTY.pathString(KnownAttribute.PSI_OUTPUT_PATH);
+      fail("expected IllegalStateException for unset output attribute");
+    }
+    catch (IllegalStateException expected) {
+      assertTrue(expected.getMessage().contains("psiOutputPath"));
+    }
+  }
+
+  public void testPathStringThrowsWhenOutputCascadeHasNoParserPath() {
+    try {
+      BnfPathsResolution.EMPTY.pathString(KnownAttribute.PARSER_OUTPUT_PATH);
+      fail("expected IllegalStateException for empty resolution");
+    }
+    catch (IllegalStateException expected) {
+      // PARSER_OUTPUT_PATH unset means the whole output cascade has nothing to fall back to.
+    }
+  }
+
+  // ---- Negative / malformed input -----------------------------------------
+
+  public void testEmptyOutputPathTreatedAsUnset() {
+    BnfFile bnf = bnfWith("g.bnf", "{ parserOutputPath=\"\" }\nroot ::= 'a'");
+    // PARSER_OUTPUT_PATH may be filled in by the parserClass-package fallback, but never by "".
+    Path resolved = BnfPaths.resolve(bnf).path(KnownAttribute.PARSER_OUTPUT_PATH);
+    if (resolved != null) {
+      assertFalse("empty string must not become a resolved path",
+                  resolved.toString().equals(bnfParent(bnf).toString() + "/"));
+    }
+  }
+
+  public void testManyDoubleDotsEscapeProjectRoot() {
+    BnfFile bnf = bnfWith("g.bnf", "{ parserOutputPath=\"../../../../../../tmp\" }\nroot ::= 'a'");
+    Path parent = bnfParent(bnf);
+    Path expected = parent.resolve("../../../../../../tmp").normalize();
+    assertEquals(expected, BnfPaths.resolve(bnf).path(KnownAttribute.PARSER_OUTPUT_PATH));
+  }
+}

--- a/tests/org/intellij/grammar/BnfTestSuite.java
+++ b/tests/org/intellij/grammar/BnfTestSuite.java
@@ -12,6 +12,7 @@ import org.intellij.grammar.actions.BnfGenerationServiceTest;
 import org.intellij.grammar.expression.ExpressionParserTest;
 import org.intellij.grammar.generator.JavaBnfGeneratorTest;
 import org.intellij.grammar.generator.KotlinBnfGeneratorTest;
+import org.intellij.grammar.generator.OutputPathOverridesTest;
 import org.intellij.grammar.inspection.BnfHighlightingTest;
 import org.intellij.grammar.intention.BnfConvertOptExpressionIntentionTest;
 import org.intellij.grammar.intention.BnfFlipChoiceIntentionTest;
@@ -37,6 +38,7 @@ public class BnfTestSuite extends TestCase {
     testSuite.addTestSuite(BnfMoveLeftRightTest.class);
     testSuite.addTestSuite(BnfConvertOptExpressionIntentionTest.class);
     testSuite.addTestSuite(BnfGeneratorPsiTest.class);
+    testSuite.addTestSuite(BnfPathsResolutionTest.class);
 
     testSuite.addTestSuite(BnfGenerationServiceIntegrationPlatformTest.class);
     testSuite.addTestSuite(JFlexCompletionTest.class);
@@ -55,6 +57,7 @@ public class BnfTestSuite extends TestCase {
       testSuite.addTestSuite(ExpressionParserTest.class);
       testSuite.addTestSuite(BnfLivePreviewParserTest.class);
       testSuite.addTestSuite(KotlinBnfGeneratorTest.class);
+      testSuite.addTestSuite(OutputPathOverridesTest.class);
       return testSuite;
     }
   }

--- a/tests/org/intellij/grammar/MainTest.java
+++ b/tests/org/intellij/grammar/MainTest.java
@@ -105,6 +105,97 @@ public class MainTest extends TestCase {
     assertContains(stdOut(), "B.bnf");
   }
 
+  public void testLegacyFormEmitsDeprecationWarning() throws Exception {
+    File inputDir = FileUtilRt.createTempDirectory("main-test-in", null, true);
+    File output = FileUtilRt.createTempDirectory("main-test-out", null, true);
+    FileUtil.writeToFile(new File(inputDir, "Grammar.bnf"),
+                         "{ parser-class=\"com.example.TestParser\" }\nroot ::= 'x'");
+
+    assertEquals(0, Main.run(new String[]{output.getAbsolutePath(), inputDir + "/Grammar.bnf"}));
+    assertContains(stdErr(), "deprecated");
+    assertContains(stdErr(), "--parser-output");
+  }
+
+  public void testNewFormParserOutputFlag() throws Exception {
+    File inputDir = FileUtilRt.createTempDirectory("main-test-in", null, true);
+    File output = FileUtilRt.createTempDirectory("main-test-out", null, true);
+    FileUtil.writeToFile(new File(inputDir, "Grammar.bnf"),
+                         "{ parser-class=\"com.example.TestParser\" }\nroot ::= 'x'");
+
+    assertEquals(0, Main.run(new String[]{
+      inputDir + "/Grammar.bnf", "--parser-output", output.getAbsolutePath()}));
+    File[] generated = output.listFiles();
+    assertNotNull(generated);
+    assertTrue("Expected generated files in output dir", generated.length > 0);
+    assertEquals("New form must not emit deprecation warning, got: " + stdErr(), "", stdErr());
+  }
+
+  public void testNewFormRejectsMultiplePositionals() throws Exception {
+    File inputDir = FileUtilRt.createTempDirectory("main-test-in", null, true);
+    File output = FileUtilRt.createTempDirectory("main-test-out", null, true);
+    FileUtil.writeToFile(new File(inputDir, "A.bnf"), "{ parser-class=\"a.A\" }\nroot ::= 'a'");
+    FileUtil.writeToFile(new File(inputDir, "B.bnf"), "{ parser-class=\"b.B\" }\nroot ::= 'b'");
+
+    int rc = Main.run(new String[]{
+      inputDir + "/A.bnf", inputDir + "/B.bnf", "--parser-output", output.getAbsolutePath()});
+    assertEquals(1, rc);
+    assertContains(stdErr(), "exactly one grammar file");
+  }
+
+  public void testConflictWarnsByDefault() throws Exception {
+    File inputDir = FileUtilRt.createTempDirectory("main-test-in", null, true);
+    File cliOut = FileUtilRt.createTempDirectory("main-test-cli", null, true);
+    File grammarOut = FileUtilRt.createTempDirectory("main-test-gram", null, true);
+    String grammarPath = grammarOut.getAbsolutePath().replace("\\", "\\\\");
+    FileUtil.writeToFile(new File(inputDir, "Grammar.bnf"),
+                         "{ parser-class=\"com.example.TestParser\"\n" +
+                         "  parserOutputPath=\"" + grammarPath + "\" }\nroot ::= 'x'");
+
+    int rc = Main.run(new String[]{
+      inputDir + "/Grammar.bnf", "--parser-output", cliOut.getAbsolutePath()});
+    assertEquals(0, rc);
+    assertContains(stdErr(), "warning:");
+    assertContains(stdErr(), "parserOutputPath");
+    assertContains(stdErr(), "overrides");
+
+    File[] cliGenerated = cliOut.listFiles();
+    assertNotNull(cliGenerated);
+    assertTrue("CLI value should win on conflict", cliGenerated.length > 0);
+  }
+
+  public void testConflictFailsInStrictMode() throws Exception {
+    File inputDir = FileUtilRt.createTempDirectory("main-test-in", null, true);
+    File cliOut = FileUtilRt.createTempDirectory("main-test-cli", null, true);
+    File grammarOut = FileUtilRt.createTempDirectory("main-test-gram", null, true);
+    String grammarPath = grammarOut.getAbsolutePath().replace("\\", "\\\\");
+    FileUtil.writeToFile(new File(inputDir, "Grammar.bnf"),
+                         "{ parser-class=\"com.example.TestParser\"\n" +
+                         "  parserOutputPath=\"" + grammarPath + "\" }\nroot ::= 'x'");
+
+    int rc = Main.run(new String[]{
+      inputDir + "/Grammar.bnf", "--parser-output", cliOut.getAbsolutePath(), "--strict-paths"});
+    assertEquals(1, rc);
+    assertContains(stdErr(), "error:");
+    assertContains(stdErr(), "parserOutputPath");
+  }
+
+  public void testNonConflictingCliFlagPassesSilently() throws Exception {
+    // CLI sets parserOutputPath; grammar sets only psiOutputPath at a different dir.
+    // No conflict, no warning. Cascade derives etHolder from grammar's psi.
+    File inputDir = FileUtilRt.createTempDirectory("main-test-in", null, true);
+    File cliOut = FileUtilRt.createTempDirectory("main-test-cli", null, true);
+    File psiOut = FileUtilRt.createTempDirectory("main-test-psi", null, true);
+    String psiPath = psiOut.getAbsolutePath().replace("\\", "\\\\");
+    FileUtil.writeToFile(new File(inputDir, "Grammar.bnf"),
+                         "{ parser-class=\"com.example.TestParser\"\n" +
+                         "  psiOutputPath=\"" + psiPath + "\" }\nroot ::= 'x'");
+
+    int rc = Main.run(new String[]{
+      inputDir + "/Grammar.bnf", "--parser-output", cliOut.getAbsolutePath()});
+    assertEquals(0, rc);
+    assertEquals("No conflict expected, got stderr: " + stdErr(), "", stdErr());
+  }
+
   private String stdOut() { return capturedOut.toString(); }
   private String stdErr() { return capturedErr.toString(); }
 

--- a/tests/org/intellij/grammar/actions/BnfGenerationServiceTest.java
+++ b/tests/org/intellij/grammar/actions/BnfGenerationServiceTest.java
@@ -98,7 +98,9 @@ public class BnfGenerationServiceTest extends BnfGeneratorTestCase {
   public void testGenerateInBatchEmptyList() {
     var ctx = new BatchGenerationContext(
       getProject(), List.of(),
-      new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>()
+      new LinkedHashMap<>(), new LinkedHashMap<>(),
+      new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(),
+      new LinkedHashMap<>()
     );
 
     List<VirtualFile> started = new ArrayList<>();
@@ -119,7 +121,9 @@ public class BnfGenerationServiceTest extends BnfGeneratorTestCase {
     // Empty rootMap: get() returns null → targetNotFound, batch stops after first file
     var ctx = new BatchGenerationContext(
       getProject(), List.of(vf1, vf2),
-      new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>()
+      new LinkedHashMap<>(), new LinkedHashMap<>(),
+      new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(),
+      new LinkedHashMap<>()
     );
 
     List<VirtualFile> startedFiles = new ArrayList<>();
@@ -143,7 +147,9 @@ public class BnfGenerationServiceTest extends BnfGeneratorTestCase {
     VirtualFile vf = createPsiFile("a.bnf", "{ }").getVirtualFile();
     var ctx = new BatchGenerationContext(
       getProject(), List.of(vf),
-      new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>()
+      new LinkedHashMap<>(), new LinkedHashMap<>(),
+      new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(),
+      new LinkedHashMap<>()
     );
 
     List<VirtualFile> generated = new ArrayList<>();
@@ -168,7 +174,7 @@ public class BnfGenerationServiceTest extends BnfGeneratorTestCase {
                                               "{ parser-class=\"com.example.TestParser\" }\nroot ::= 'x'");
 
     Generator gen = BnfGenerationService.createGenerator(
-      bnfFile, "", new File("."), new File("."), "", new ArrayList<>()
+      bnfFile, "", "", new ArrayList<>()
     );
 
     assertInstanceOf(gen, JavaParserGenerator.class);
@@ -179,7 +185,7 @@ public class BnfGenerationServiceTest extends BnfGeneratorTestCase {
                                               "{ generate=[parser-api=\"syntax\"] parser-class=\"com.example.TestParser\" }\nroot ::= 'x'");
 
     Generator gen = BnfGenerationService.createGenerator(
-      bnfFile, "", new File("."), new File("."), "", new ArrayList<>()
+      bnfFile, "", "", new ArrayList<>()
     );
 
     assertInstanceOf(gen, KotlinParserGenerator.class);

--- a/tests/org/intellij/grammar/generator/JavaBnfGeneratorTest.java
+++ b/tests/org/intellij/grammar/generator/JavaBnfGeneratorTest.java
@@ -4,11 +4,16 @@
 
 package org.intellij.grammar.generator;
 
+import org.intellij.grammar.KnownAttribute;
 import org.intellij.grammar.psi.BnfFile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
+
+import static org.intellij.grammar.psi.BnfAttributes.getRootAttribute;
 
 public class JavaBnfGeneratorTest extends AbstractBnfGeneratorTest {
   public JavaBnfGeneratorTest() {
@@ -116,6 +121,22 @@ public class JavaBnfGeneratorTest extends AbstractBnfGeneratorTest {
   protected @NotNull List<@NotNull Generator> createGenerators(@NotNull BnfFile psiFile,
                                                                @NotNull String outputPath,
                                                                @NotNull OutputOpener outputOpener) {
-    return List.of(new JavaParserGenerator(psiFile, "", outputPath, "", outputOpener));
+    java.nio.file.Path parserPath    = resolveTestPath(psiFile, KnownAttribute.PARSER_OUTPUT_PATH);
+    java.nio.file.Path etHolderPath  = resolveTestPath(psiFile, KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH);
+    java.nio.file.Path converterPath = resolveTestPath(psiFile, KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH);
+    // PSI_OUTPUT_PATH is intentionally ignored in pure-Java mode (it is a Kotlin/syntax-api-only attribute).
+    java.util.Map<KnownAttribute<String>, java.nio.file.Path> map = new java.util.HashMap<>();
+    map.put(KnownAttribute.PARSER_OUTPUT_PATH, parserPath != null ? parserPath : java.nio.file.Path.of(outputPath));
+    if (etHolderPath != null) map.put(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH, etHolderPath);
+    if (converterPath != null) map.put(KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH, converterPath);
+    org.intellij.grammar.BnfPathsResolution paths = org.intellij.grammar.BnfPaths.resolveExplicit(map);
+    return List.of(new JavaParserGenerator(psiFile, "", "", outputOpener, paths));
+  }
+
+  private @Nullable java.nio.file.Path resolveTestPath(@NotNull BnfFile psiFile, @NotNull KnownAttribute<String> attr) {
+    String relative = getRootAttribute(psiFile, attr);
+    if (relative == null) return null;
+    String projectPath = myFullDataPath.substring(0, myFullDataPath.lastIndexOf(File.separatorChar) + 1);
+    return java.nio.file.Path.of(projectPath + relative);
   }
 }

--- a/tests/org/intellij/grammar/generator/KotlinBnfGeneratorTest.java
+++ b/tests/org/intellij/grammar/generator/KotlinBnfGeneratorTest.java
@@ -4,13 +4,19 @@
 
 package org.intellij.grammar.generator;
 
+import org.intellij.grammar.BnfPaths;
+import org.intellij.grammar.BnfPathsResolution;
 import org.intellij.grammar.KnownAttribute;
 import org.intellij.grammar.psi.BnfFile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.intellij.grammar.psi.BnfAttributes.getRootAttribute;
 
@@ -25,10 +31,26 @@ public class KotlinBnfGeneratorTest extends AbstractBnfGeneratorTest {
   protected @NotNull List<@NotNull Generator> createGenerators(@NotNull BnfFile psiFile,
                                                                @NotNull String outputPath,
                                                                @NotNull OutputOpener outputOpener) {
-    String psiModulePath = getRootAttribute(psiFile, KnownAttribute.PSI_OUTPUT_PATH);
-    String myProjectPath = myFullDataPath.substring(0, myFullDataPath.lastIndexOf(File.separatorChar) + 1);
-    String psiOutputPath = !psiModulePath.isEmpty() ? myProjectPath + psiModulePath : "";
-    return List.of(new KotlinParserGenerator(psiFile, "", outputPath, psiOutputPath, "", outputOpener));
+    Path parserPath        = resolveTestPath(psiFile, KnownAttribute.PARSER_OUTPUT_PATH);
+    Path psiPath           = resolveTestPath(psiFile, KnownAttribute.PSI_OUTPUT_PATH);
+    Path etHolderPath      = resolveTestPath(psiFile, KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH);
+    Path syntaxHolderPath  = resolveTestPath(psiFile, KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH);
+    Path converterPath     = resolveTestPath(psiFile, KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH);
+    Map<KnownAttribute<String>, Path> map = new HashMap<>();
+    map.put(KnownAttribute.PARSER_OUTPUT_PATH, parserPath != null ? parserPath : Path.of(outputPath));
+    if (psiPath != null) map.put(KnownAttribute.PSI_OUTPUT_PATH, psiPath);
+    if (etHolderPath != null) map.put(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH, etHolderPath);
+    if (syntaxHolderPath != null) map.put(KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH, syntaxHolderPath);
+    if (converterPath != null) map.put(KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH, converterPath);
+    BnfPathsResolution paths = BnfPaths.resolveExplicit(map);
+    return List.of(new KotlinParserGenerator(psiFile, "", "", outputOpener, paths));
+  }
+
+  private @Nullable Path resolveTestPath(@NotNull BnfFile psiFile, @NotNull KnownAttribute<String> attr) {
+    String relative = getRootAttribute(psiFile, attr);
+    if (relative == null) return null;
+    String projectPath = myFullDataPath.substring(0, myFullDataPath.lastIndexOf(File.separatorChar) + 1);
+    return Path.of(projectPath + relative);
   }
 
   @Override

--- a/tests/org/intellij/grammar/generator/OutputPathOverridesTest.java
+++ b/tests/org/intellij/grammar/generator/OutputPathOverridesTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2011-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.intellij.grammar.generator;
+
+import com.intellij.openapi.util.io.FileUtilRt;
+import org.intellij.grammar.BnfGeneratorTestCase;
+import org.intellij.grammar.BnfPaths;
+import org.intellij.grammar.KnownAttribute;
+import org.intellij.grammar.psi.BnfFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Verifies that the per-artifact {@code *_OUTPUT_PATH} attributes route generated files to the
+ * directories supplied via the generator constructors. The assertions look only at the
+ * {@code File} each {@link OutputOpener#openOutput} call receives, so this test is independent
+ * of the generated source content.
+ */
+public class OutputPathOverridesTest extends BnfGeneratorTestCase {
+
+  private static final String GRAMMAR =
+    "{\n" +
+    "  generate=[parser-api=\"syntax\"]\n" +
+    "  parserClass=\"generated.OutputPathsParser\"\n" +
+    "  elementTypeHolderClass=\"generated.GenTypes\"\n" +
+    "  syntaxElementTypeHolderClass=\"generated.GenSyntaxTypes\"\n" +
+    "  elementTypeConverterFactoryClass=\"generated.GenConverterFactory\"\n" +
+    "  psiPackage=\"generated.psi\"\n" +
+    "  psiImplPackage=\"generated.psi.impl\"\n" +
+    "  psiClassPrefix=\"X\"\n" +
+    "}\n" +
+    "\n" +
+    "root ::= 'a' 'b'\n" +
+    "foo  ::= 'a' root\n";
+
+  private final String tempBase = FileUtilRt.getTempDirectory();
+  private final String parserDir   = tempBase + "/op/parser";
+  private final String psiDir      = tempBase + "/op/psi";
+  private final String etHolderDir = tempBase + "/op/types";
+  private final String syntaxDir   = tempBase + "/op/syntaxtypes";
+  private final String converterDir= tempBase + "/op/converter";
+
+  public OutputPathOverridesTest() {
+    super("java");
+  }
+
+  /** Java-mode: parserOutputPath / psiOutputPath / elementTypeHolderOutputPath. */
+  public void testJavaModeRoutesEachArtifactToItsOverride() throws Exception {
+    BnfFile bnfFile = (BnfFile)createPsiFile("OutputPaths.bnf",
+                                             GRAMMAR.replace("generate=[parser-api=\"syntax\"]", ""));
+
+    Map<String, File> captured = new LinkedHashMap<>();
+    OutputOpener opener = capturingOpener(captured);
+
+    Map<KnownAttribute<String>, Path> map = new HashMap<>();
+    map.put(KnownAttribute.PARSER_OUTPUT_PATH, Path.of(parserDir));
+    map.put(KnownAttribute.PSI_OUTPUT_PATH, Path.of(psiDir));
+    map.put(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH, Path.of(etHolderDir));
+    JavaParserGenerator gen = new JavaParserGenerator(
+      bnfFile, "", "", opener, BnfPaths.resolveExplicit(map)
+    );
+    gen.generate();
+
+    assertParent("generated.OutputPathsParser",            captured, parserDir);
+    assertParent("generated.GenTypes",                     captured, etHolderDir);
+    assertParentStartsWith("generated.psi.XFoo",           captured, psiDir);
+    assertParentStartsWith("generated.psi.impl.XFooImpl",  captured, psiDir);
+    // The visitor is part of the PSI bundle and must follow PSI_OUTPUT_PATH too.
+    assertParentStartsWith("generated.psi.XVisitor",       captured, psiDir);
+  }
+
+  /** Kotlin-mode: adds syntaxElementTypeHolderOutputPath and elementTypeConverterFactoryOutputPath. */
+  public void testKotlinModeRoutesEachArtifactToItsOverride() throws Exception {
+    BnfFile bnfFile = (BnfFile)createPsiFile("OutputPaths.bnf", GRAMMAR);
+
+    Map<String, File> captured = new LinkedHashMap<>();
+    OutputOpener opener = capturingOpener(captured);
+
+    Map<KnownAttribute<String>, Path> map = new HashMap<>();
+    map.put(KnownAttribute.PARSER_OUTPUT_PATH, Path.of(parserDir));
+    map.put(KnownAttribute.PSI_OUTPUT_PATH, Path.of(psiDir));
+    map.put(KnownAttribute.ELEMENT_TYPE_HOLDER_OUTPUT_PATH, Path.of(etHolderDir));
+    map.put(KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_OUTPUT_PATH, Path.of(syntaxDir));
+    map.put(KnownAttribute.ELEMENT_TYPE_CONVERTER_FACTORY_OUTPUT_PATH, Path.of(converterDir));
+    KotlinParserGenerator gen = new KotlinParserGenerator(
+      bnfFile, "", "", opener, BnfPaths.resolveExplicit(map)
+    );
+    gen.generate();
+
+    assertParent("generated.OutputPathsParser",            captured, parserDir);
+    assertParent("generated.GenSyntaxTypes",               captured, syntaxDir);
+    assertParent("generated.GenTypes",                     captured, etHolderDir);
+    assertParent("generated.GenConverterFactory",          captured, converterDir);
+    assertParentStartsWith("generated.psi.XFoo",           captured, psiDir);
+    assertParentStartsWith("generated.psi.impl.XFooImpl",  captured, psiDir);
+    assertParentStartsWith("generated.psi.XVisitor",       captured, psiDir);
+  }
+
+  /** When overrides are null, every artifact falls back to the parser/psi outputPath (today's behavior). */
+  public void testNullOverridesFallBackToOutputPath() throws Exception {
+    BnfFile bnfFile = (BnfFile)createPsiFile("OutputPaths.bnf",
+                                             GRAMMAR.replace("generate=[parser-api=\"syntax\"]", ""));
+
+    Map<String, File> captured = new LinkedHashMap<>();
+    OutputOpener opener = capturingOpener(captured);
+
+    JavaParserGenerator gen = new JavaParserGenerator(
+      bnfFile, "", "", opener,
+      BnfPaths.resolveExplicit(Map.of(KnownAttribute.PARSER_OUTPUT_PATH, Path.of(parserDir)))
+    );
+    gen.generate();
+
+    // Every artifact should have parserDir as its root prefix.
+    assertParent("generated.OutputPathsParser",            captured, parserDir);
+    assertParent("generated.GenTypes",                     captured, parserDir);
+    assertParentStartsWith("generated.psi.XFoo",           captured, parserDir);
+    assertParentStartsWith("generated.psi.impl.XFooImpl",  captured, parserDir);
+    assertParentStartsWith("generated.psi.XVisitor",       captured, parserDir);
+  }
+
+  // ---- helpers ----
+
+  private static @NotNull OutputOpener capturingOpener(@NotNull Map<String, File> captured) {
+    return (className, file, bnfFile) -> {
+      captured.put(className, file);
+      return new PrintWriter(new StringWriter());  // discard generated content
+    };
+  }
+
+  /** Asserts the captured file for {@code className} sits under {@code expectedRootDir} with FQN-as-path. */
+  private static void assertParent(@NotNull String className, @NotNull Map<String, File> captured,
+                                   @NotNull String expectedRootDir) {
+    File actual = require(className, captured);
+    File expected = new File(expectedRootDir, className.replace('.', File.separatorChar) + "." + ext(actual));
+    assertEquals("Wrong path for " + className, expected.getAbsolutePath(), actual.getAbsolutePath());
+  }
+
+  private static void assertParentStartsWith(@NotNull String className, @NotNull Map<String, File> captured,
+                                             @NotNull String expectedRootDir) {
+    File actual = require(className, captured);
+    String prefix = new File(expectedRootDir).getAbsolutePath() + File.separator;
+    assertTrue("Path for " + className + " expected to start with " + prefix + " but was " + actual.getAbsolutePath(),
+               actual.getAbsolutePath().startsWith(prefix));
+  }
+
+  private static @NotNull File require(@NotNull String className, @NotNull Map<String, File> captured) {
+    File f = captured.get(className);
+    assertNotNull("Generator did not emit " + className + ". Captured: " + captured.keySet(), f);
+    return f;
+  }
+
+  private static @NotNull String ext(@NotNull File f) {
+    String name = f.getName();
+    int dot = name.lastIndexOf('.');
+    return dot < 0 ? "" : name.substring(dot + 1);
+  }
+}


### PR DESCRIPTION
## Summary
                                                                                                                                                                                     
  Lets grammar authors pin each generated artifact to its own directory via                                                                                                          
  new global attributes, parallel to the existing `psiOutputPath`. All values                                                                                                        
  are resolved relative to the BNF file's parent directory.                                                                                                                          
                  
  New attributes (all optional, default `null` = derive default location):                                                                                                           
                  
  | Attribute | Targets |                                                                                                                                                            
  |---|---|       
  | `parserOutputPath` | parser `.java` / `.kt` |                                                                                                                                    
  | `elementTypeHolderOutputPath` | Java `IElementType` holder |
  | `syntaxElementTypeHolderOutputPath` | Kotlin syntax-element-type holder |                                                                                                        
  | `elementTypeConverterFactoryOutputPath` | syntax-API converter factory |                                                                                                         
                                                                                                                                                                                     
  Plus a behavior change: `psiOutputPath` now applies in **both** Java and                                                                                                           
  Kotlin generation modes (it was Kotlin-only before).                                                                                                                               
                                                                                                                                                                                     
  ## Implementation notes
  - New `Generator.PathOverrides` record bundles the four nullable override                                                                                                          
    paths and is shared by `JavaParserGenerator` and `KotlinParserGenerator`,                                                                                                        
    removing duplicated fields and `nullIfEmpty` boilerplate from both.      
  - `Generator.openOutput(className, alternateOutputPath)` overload routes a                                                                                                         
    single artifact to a per-attribute directory; falls back to `myOutputPath`                                                                                                       
    when the override is null.                                                                                                                                                       
  - `BnfGenerationService.prepareGenerationContext` honors `parserOutputPath`                                                                                                        
    by skipping the parser-class-package derivation (`getTargetDirectoryFor`)                                                                                                        
    when an explicit value is set.                                                                                                                                                   
  - Replaced the heavyweight `FileGeneratorUtil.getTargetDirectoryRelativeToContentRoot`                                                                                             
    with a one-liner BNF-relative resolver                                                                                                                                           
    (`VirtualFileUtil.findOrCreateDirectory(bnfFile.getParent(), relativePath)`).                                                                                                    
    No more source-root detection, gen-dir prepending, or package-prefix                                                                                                             
    manipulation — the explicit path wins verbatim.                                                                                                                                  
  - `generateGrammar` now registers every output folder (parser, PSI, IElement                                                                                                       
    holder, syntax-type holder, converter factory) in `targets` so the IDE                                                                                                           
    refreshes each one after generation. `collectTarget` /                                                                                                                           
    `collectOptionalTarget` helpers keep nullability tight.                                                                                                                          
  - HTML attribute-description files added/updated for all five path attributes.                                                                                                     
                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                       
                                                                                                                                                                                     
  - [x] `OutputPathOverridesTest` (new, 3 cases): captures `(className, file)`                                                                                                       
        tuples a generator routes each artifact to and asserts the per-attribute                                                                                                     
        directory in both Java and Kotlin modes plus a null-overrides fallback case.
  - [x] Full `BnfTestSuite` passes — every existing `*.expected.{java,kt}`                                                                                                           
        baseline is byte-identical (defaults to `null` means no behavior change                                                                                                      
        when no attribute is set).                                                                                                                                                   
  - [x] `BnfGenerationServiceTest` factory tests still pass after the                                                                                                                
        `createGenerator` and `BatchGenerationContext` signature changes.                                                                                                            
  - [x] Manual smoke test: open a `.bnf` with                                                                                                                                        
        `parserOutputPath="custom/parser"` and confirm the parser file lands                                                                                                         
        under `<bnfParent>/custom/parser/...` rather than the parser-class                                                                                                           
        package directory.   