### PR TITLE
cleanup: drop two unused imports

### DIFF
--- a/generator/src/org/intellij/grammar/generator/ParserGeneratorUtil.java
+++ b/generator/src/org/intellij/grammar/generator/ParserGeneratorUtil.java
@@ -17,7 +17,6 @@ import com.intellij.util.containers.TreeTraversal;
 import org.intellij.grammar.KnownAttribute;
 import org.intellij.grammar.generator.java.JavaBnfConstants;
 import org.intellij.grammar.generator.java.JavaNames;
-import org.intellij.grammar.java.JavaHelper;
 import org.intellij.grammar.java.TypeParameterInfo;
 import org.intellij.grammar.psi.*;
 import org.intellij.grammar.psi.impl.GrammarUtil;

--- a/generator/src/org/intellij/grammar/generator/batch/FileGeneratorUtil.java
+++ b/generator/src/org/intellij/grammar/generator/batch/FileGeneratorUtil.java
@@ -20,7 +20,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileUtil;
 import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.ProjectScope;
-import org.intellij.grammar.BnfFileType;
 import org.intellij.grammar.config.Options;
 import org.intellij.grammar.generator.CommonBnfConstants;
 


### PR DESCRIPTION
ParserGeneratorUtil does not reference JavaHelper, and FileGeneratorUtil does not reference BnfFileType.