### PR TITLE
cleanup: hoist duplicated generator state and helpers into Generator

### DIFF
--- a/generator/src/org/intellij/grammar/generator/Generator.java
+++ b/generator/src/org/intellij/grammar/generator/Generator.java
@@ -11,12 +11,15 @@ import com.intellij.openapi.ui.MessageType;
 import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiElement;
+import com.intellij.util.ObjectUtils;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.JBIterable;
 import com.intellij.util.containers.MultiMap;
 import org.intellij.grammar.KnownAttribute;
 import org.intellij.grammar.analysis.BnfFirstNextAnalyzer;
 import org.intellij.grammar.generator.NodeCalls.*;
+import org.intellij.grammar.java.JavaHelper;
 import org.intellij.grammar.psi.*;
 import org.intellij.grammar.psi.impl.GrammarUtil;
 import org.jetbrains.annotations.NotNull;
@@ -28,7 +31,10 @@ import java.util.*;
 
 import static java.lang.String.format;
 import static org.intellij.grammar.generator.ParserGeneratorUtil.ConsumeType;
+import static org.intellij.grammar.generator.ParserGeneratorUtil.getRegexpTokenRegexp;
 import static org.intellij.grammar.generator.ParserGeneratorUtil.getTokenType;
+import static org.intellij.grammar.generator.ParserGeneratorUtil.isRegexpToken;
+import static org.intellij.grammar.generator.ParserGeneratorUtil.matchesAny;
 import static org.intellij.grammar.generator.RuleGraphHelper.hasElementType;
 import static org.intellij.grammar.psi.BnfAst.*;
 import static org.intellij.grammar.psi.BnfAttributes.getAttribute;
@@ -62,6 +68,8 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
   private FilePrinter myPrinter;
   protected final RuleGraphHelper myGraphHelper;
   protected final BnfFirstNextAnalyzer myFirstNextAnalyzer;
+  protected final ExpressionHelper myExpressionHelper;
+  protected final JavaHelper myJavaHelper;
 
   final @NotNull Map<String, RuleInfo> myRuleInfos = new TreeMap<>();
 
@@ -79,6 +87,11 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
    * 2.
    */
   protected final Map<String, String> mySimpleTokens;
+
+  /**
+   * Names of the tokens the grammar consumes, collected as consume calls are emitted.
+   */
+  protected final @NotNull Set<String> myTokensUsedInGrammar = new LinkedHashSet<>();
 
   /**
    * Maps field names to their corresponding parser function bodies.
@@ -118,13 +131,14 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
     myOutputFileExtension = outputFileExtension;
     myOpener = outputOpener;
 
-    List<BnfRule> rules = psiFile.getRules();
-    BnfRule rootRule = rules.isEmpty() ? null : rules.get(0);
+    BnfRule rootRule = ContainerUtil.getFirstItem(psiFile.getRules());
     myGrammarRoot = rootRule == null ? null : rootRule.getName();
     myGrammarRootParser = rootRule == null ? null : getRootAttribute(rootRule, KnownAttribute.PARSER_CLASS);
     mySimpleTokens = new LinkedHashMap<>(getTokenTextToNameMap(myFile));
     myGraphHelper = RuleGraphHelper.getCached(psiFile);
     myFirstNextAnalyzer = BnfFirstNextAnalyzer.createAnalyzer(true);
+    myExpressionHelper = new ExpressionHelper(myFile, myGraphHelper, this::addWarning);
+    myJavaHelper = JavaHelper.getJavaHelper(myFile);
   }
 
   public abstract void generate() throws IOException;
@@ -436,6 +450,46 @@ public sealed abstract class Generator permits JavaParserGenerator, KotlinParser
   @NotNull String formatMetaParamName(@NotNull String s) {
     String argName = s.trim();
     return N.metaParamPrefix + (N.metaParamPrefix.isEmpty() || "_".equals(N.metaParamPrefix) ? argName : StringUtil.capitalize(argName));
+  }
+
+  protected final @NotNull List<String> collectMetaParametersFormatted(@NotNull BnfRule rule, @Nullable BnfExpression expression) {
+    if (expression == null) return Collections.emptyList();
+    return ContainerUtil.map(GrammarUtil.collectMetaParameters(rule, expression),
+                             it -> formatMetaParamName(it.substring(2, it.length() - 2)));
+  }
+
+  protected final @NotNull ConsumeType getRuleConsumeType(@NotNull BnfRule rule, @Nullable BnfRule contextRule) {
+    ConsumeType forcedConsumeType = ExpressionGeneratorHelper.fixForcedConsumeType(myExpressionHelper, rule, null, null);
+    if (forcedConsumeType != null && contextRule != null && myExpressionHelper.getExpressionInfo(contextRule) == null) {
+      // do not force child expr consume-type in a non-expr context
+      forcedConsumeType = null;
+    }
+    return ObjectUtils.chooseNotNull(forcedConsumeType, ConsumeType.forRule(rule));
+  }
+
+  protected final @NotNull ConsumeType getEffectiveConsumeType(@NotNull BnfRule rule,
+                                                               @Nullable BnfExpression node,
+                                                               @Nullable ConsumeType forcedConsumeType) {
+    if (forcedConsumeType == ConsumeType.DEFAULT) return ConsumeType.DEFAULT;
+    PsiElement parent = node == null ? null : node.getParent();
+
+    if (forcedConsumeType == null && parent instanceof BnfSequence &&
+        ContainerUtil.getFirstItem(((BnfSequence)parent).getExpressionList()) != node) {
+      Set<BnfExpression> expressions = BnfFirstNextAnalyzer.createAnalyzer(false, false, o -> o != parent)
+        .calcFirst((BnfExpression)parent);
+      if (expressions.size() != 1 || expressions.iterator().next() != node) {
+        return ConsumeType.DEFAULT;
+      }
+    }
+    ConsumeType fixed = ExpressionGeneratorHelper.fixForcedConsumeType(myExpressionHelper, rule, node, forcedConsumeType);
+    return fixed != null ? fixed : ConsumeType.forRule(rule);
+  }
+
+  protected final boolean isIgnoredWhitespaceToken(@NotNull String tokenName, @NotNull String tokenText) {
+    return isRegexpToken(tokenText) &&
+           !myTokensUsedInGrammar.contains(tokenName) &&
+           matchesAny(getRegexpTokenRegexp(tokenText), " ", "\n") &&
+           !matchesAny(getRegexpTokenRegexp(tokenText), "a", "1", "_", ".");
   }
 
   @NotNull

--- a/generator/src/org/intellij/grammar/generator/JavaParserGenerator.java
+++ b/generator/src/org/intellij/grammar/generator/JavaParserGenerator.java
@@ -67,10 +67,8 @@ import static org.intellij.grammar.psi.BnfTypes.*;
 public final class JavaParserGenerator extends Generator {
   public static final Logger LOG = Logger.getInstance(JavaParserGenerator.class);
   
-  private final Set<String> myTokensUsedInGrammar = new LinkedHashSet<>();
   private final boolean myNoStubs;
 
-  private final String myGrammarRoot;
   private final String myGrammarRootParser;
   private final String myParserUtilClass;
   private final String myPsiImplUtilClass;
@@ -83,9 +81,7 @@ public final class JavaParserGenerator extends Generator {
   private final String myParserTypeHolderClass;
   private final String myPsiElementTypeHolderClass;
 
-  private final ExpressionHelper myExpressionHelper;
   private final RuleMethodsHelper myRulesMethodsHelper;
-  private final JavaHelper myJavaHelper;
 
   public JavaParserGenerator(@NotNull BnfFile psiFile,
                              @NotNull String sourcePath,
@@ -108,13 +104,10 @@ public final class JavaParserGenerator extends Generator {
     myParserTypeHolderClass = getRootAttribute(myFile, KnownAttribute.ELEMENT_TYPE_HOLDER_CLASS);
     myPsiElementTypeHolderClass = getRootAttribute(myFile, KnownAttribute.ELEMENT_TYPE_HOLDER_CLASS);
 
-    myExpressionHelper = new ExpressionHelper(myFile, myGraphHelper, this::addWarning);
     myRulesMethodsHelper = new RuleMethodsHelper(myGraphHelper, myExpressionHelper, mySimpleTokens, G);
-    myJavaHelper = JavaHelper.getJavaHelper(myFile);
 
     List<BnfRule> rules = psiFile.getRules();
-    BnfRule rootRule = rules.isEmpty() ? null : rules.get(0);
-    myGrammarRoot = rootRule == null ? null : rootRule.getName();
+    BnfRule rootRule = ContainerUtil.getFirstItem(rules);
     for (BnfRule r : rules) {
       String ruleName = r.getName();
       boolean noPsi = !hasPsiClass(r);
@@ -876,21 +869,6 @@ public final class JavaParserGenerator extends Generator {
     return dropFrameName && StringUtil.isEmpty(getAttribute(rule, KnownAttribute.NAME)) ? null : frameName;
   }
 
-  private @NotNull ConsumeType getRuleConsumeType(@NotNull BnfRule rule, @Nullable BnfRule contextRule) {
-    ConsumeType forcedConsumeType = ExpressionGeneratorHelper.fixForcedConsumeType(myExpressionHelper, rule, null, null);
-    if (forcedConsumeType != null && contextRule != null && myExpressionHelper.getExpressionInfo(contextRule) == null) {
-      // do not force child expr consume-type in a non-expr context
-      forcedConsumeType = null;
-    }
-    return ObjectUtils.chooseNotNull(forcedConsumeType, ConsumeType.forRule(rule));
-  }
-
-  private @NotNull List<String> collectMetaParametersFormatted(@NotNull BnfRule rule, @Nullable BnfExpression expression) {
-    if (expression == null) return Collections.emptyList();
-    return map(GrammarUtil.collectMetaParameters(rule, expression),
-               it -> formatMetaParamName(it.substring(2, it.length() - 2)));
-  }
-
   @Override
   @NotNull NodeCall generateTokenSequenceCall(List<BnfExpression> children,
                                                       int startIndex,
@@ -1014,24 +992,6 @@ public final class JavaParserGenerator extends Generator {
         return new MetaMethodCall(null, nextName, N.builder, N.level, map(extraArguments, MetaParameterArgument::new));
       }
     }
-  }
-
-  private @NotNull ConsumeType getEffectiveConsumeType(@NotNull BnfRule rule,
-                                                       @Nullable BnfExpression node,
-                                                       @Nullable ConsumeType forcedConsumeType) {
-    if (forcedConsumeType == ConsumeType.DEFAULT) return ConsumeType.DEFAULT;
-    PsiElement parent = node == null ? null : node.getParent();
-
-    if (forcedConsumeType == null && parent instanceof BnfSequence &&
-        ContainerUtil.getFirstItem(((BnfSequence)parent).getExpressionList()) != node) {
-      Set<BnfExpression> expressions = BnfFirstNextAnalyzer.createAnalyzer(false, false, o -> o != parent)
-        .calcFirst((BnfExpression)parent);
-      if (expressions.size() != 1 || expressions.iterator().next() != node) {
-        return ConsumeType.DEFAULT;
-      }
-    }
-    ConsumeType fixed = ExpressionGeneratorHelper.fixForcedConsumeType(myExpressionHelper, rule, node, forcedConsumeType);
-    return fixed != null ? fixed : ConsumeType.forRule(rule);
   }
 
   @NotNull NodeCall generateExternalCall(@NotNull BnfRule rule,
@@ -1235,13 +1195,6 @@ public final class JavaParserGenerator extends Generator {
       out("}");
     }
     out("}");
-  }
-
-  private boolean isIgnoredWhitespaceToken(@NotNull String tokenName, @NotNull String tokenText) {
-    return isRegexpToken(tokenText) &&
-           !myTokensUsedInGrammar.contains(tokenName) &&
-           matchesAny(getRegexpTokenRegexp(tokenText), " ", "\n") &&
-           !matchesAny(getRegexpTokenRegexp(tokenText), "a", "1", "_", ".");
   }
 
   private void generateTokenSets() {

--- a/generator/src/org/intellij/grammar/generator/KotlinParserGenerator.java
+++ b/generator/src/org/intellij/grammar/generator/KotlinParserGenerator.java
@@ -67,15 +67,6 @@ public final class KotlinParserGenerator extends Generator {
 
   private final @NotNull Collection<String> mySGPRMethods = Arrays.asList("eof", "advanceToken");
 
-  /**
-   * Contains names of all the tokens whose corresponding {@code SyntaxElementType}
-   * definitions were generated.
-   */
-  private final @NotNull Set<String> myTokensUsedInGrammar = new LinkedHashSet<>();
-
-  private final ExpressionHelper myExpressionHelper;
-  private final JavaHelper myJavaHelper;
-
   public KotlinParserGenerator(@NotNull BnfFile psiFile,
                                @NotNull String sourcePath,
                                @NotNull String outputPath,
@@ -89,9 +80,6 @@ public final class KotlinParserGenerator extends Generator {
     myElementTypesHolderName = getRootAttribute(myFile, KnownAttribute.SYNTAX_ELEMENT_TYPE_HOLDER_CLASS);
     myParserUtil = getRootAttribute(myFile, KnownAttribute.SYNTAX_PARSER_UTIL_OBJECT);
     myPsiOutputPath = (psiOutputPath.isEmpty()) ? myOutputPath : psiOutputPath;
-
-    myExpressionHelper = new ExpressionHelper(myFile, myGraphHelper, this::addWarning);
-    myJavaHelper = JavaHelper.getJavaHelper(myFile);
 
     for (final var rule : psiFile.getRules()) {
       final var ruleName = rule.getName();
@@ -1051,21 +1039,6 @@ public final class KotlinParserGenerator extends Generator {
     return "{ %s, %s -> %s }".formatted(N.runtime, N.level, body);
   }
 
-  private @NotNull ConsumeType getRuleConsumeType(@NotNull BnfRule rule, @Nullable BnfRule contextRule) {
-    ConsumeType forcedConsumeType = ExpressionGeneratorHelper.fixForcedConsumeType(myExpressionHelper, rule, null, null);
-    if (forcedConsumeType != null && contextRule != null && myExpressionHelper.getExpressionInfo(contextRule) == null) {
-      // do not force child expr consume-type in a non-expr context
-      forcedConsumeType = null;
-    }
-    return ObjectUtils.chooseNotNull(forcedConsumeType, ConsumeType.forRule(rule));
-  }
-
-  private @NotNull List<String> collectMetaParametersFormatted(@NotNull BnfRule rule, @Nullable BnfExpression expression) {
-    if (expression == null) return Collections.emptyList();
-    return map(GrammarUtil.collectMetaParameters(rule, expression),
-               it -> formatMetaParamName(it.substring(2, it.length() - 2)));
-  }
-
   @Override
   @NotNull NodeCall generateTokenSequenceCall(@NotNull List<BnfExpression> children,
                                                     int startIndex,
@@ -1200,24 +1173,6 @@ public final class KotlinParserGenerator extends Generator {
     }
   }
 
-  private @NotNull ConsumeType getEffectiveConsumeType(@NotNull BnfRule rule,
-                                                       @Nullable BnfExpression node,
-                                                       @Nullable ConsumeType forcedConsumeType) {
-    if (forcedConsumeType == ConsumeType.DEFAULT) return ConsumeType.DEFAULT;
-    PsiElement parent = node == null ? null : node.getParent();
-
-    if (forcedConsumeType == null && parent instanceof BnfSequence &&
-        ContainerUtil.getFirstItem(((BnfSequence)parent).getExpressionList()) != node) {
-      Set<BnfExpression> expressions = BnfFirstNextAnalyzer.createAnalyzer(false, false, o -> o != parent)
-        .calcFirst((BnfExpression)parent);
-      if (expressions.size() != 1 || expressions.iterator().next() != node) {
-        return ConsumeType.DEFAULT;
-      }
-    }
-    ConsumeType fixed = ExpressionGeneratorHelper.fixForcedConsumeType(myExpressionHelper, rule, node, forcedConsumeType);
-    return fixed != null ? fixed : ConsumeType.forRule(rule);
-  }
-
   private @NotNull NodeCall generateExternalCall(@NotNull BnfRule rule,
                                                @NotNull List<BnfExpression> expressions,
                                                @NotNull String nextName) {
@@ -1251,13 +1206,6 @@ public final class KotlinParserGenerator extends Generator {
   }
 
   // region Utils
-
-  private boolean isIgnoredWhitespaceToken(@NotNull String tokenName, @NotNull String tokenText) {
-    return isRegexpToken(tokenText) &&
-           !myTokensUsedInGrammar.contains(tokenName) &&
-           matchesAny(getRegexpTokenRegexp(tokenText), " ", "\n") &&
-           !matchesAny(getRegexpTokenRegexp(tokenText), "a", "1", "_", ".");
-  }
 
   // endregion Utils
 }

--- a/tests/org/intellij/grammar/BnfGeneratorPsiTest.java
+++ b/tests/org/intellij/grammar/BnfGeneratorPsiTest.java
@@ -10,6 +10,7 @@ import com.intellij.psi.*;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import com.intellij.util.ProcessingContext;
+import org.intellij.grammar.generator.Generator;
 import org.intellij.grammar.generator.JavaParserGenerator;
 import org.intellij.grammar.generator.NameShortener;
 import org.intellij.grammar.generator.OutputOpener;
@@ -237,7 +238,7 @@ public class BnfGeneratorPsiTest extends BasePlatformTestCase {
     // PsiHelper.getAnnotationsInner() fails to filter @NotNull from method annotations
     // when PsiType.getAnnotations() doesn't return annotations on inner type components
     // of qualified types. We simulate this by wrapping the JavaHelper.
-    Field javaHelperField = JavaParserGenerator.class.getDeclaredField("myJavaHelper");
+    Field javaHelperField = Generator.class.getDeclaredField("myJavaHelper");
     javaHelperField.setAccessible(true);
     JavaHelper original = (JavaHelper) javaHelperField.get(generator);
     javaHelperField.set(generator, new DuplicateAnnotationJavaHelper(original));


### PR DESCRIPTION
JavaParserGenerator and KotlinParserGenerator declare myExpressionHelper, myJavaHelper and myTokensUsedInGrammar with the same initializers, and carry byte-identical copies of getRuleConsumeType, getEffectiveConsumeType, collectMetaParametersFormatted and isIgnoredWhitespaceToken. Move all of them to the shared base.

Generator is sealed, so protected exposes nothing outside the hierarchy.

JavaParserGenerator also shadowed Generator.myGrammarRoot with the same expression the base already evaluates; drop the shadow. myGrammarRootParser stays: the base computes it from the root attribute while the subclass takes it from RuleInfo, so the two generators disagree once the root rule declares its own parserClass. Unifying that changes generated output.

BnfGeneratorPsiTest reads myJavaHelper through getDeclaredField, which only sees fields of the exact class, so it now asks Generator for it.