### PR TITLE
cleanup: use platform collection helpers

### DIFF
--- a/generator/src/org/intellij/grammar/generator/JavaParserGenerator.java
+++ b/generator/src/org/intellij/grammar/generator/JavaParserGenerator.java
@@ -271,7 +271,7 @@ public final class JavaParserGenerator extends Generator {
   private void generateVisitor(String psiClass, Map<String, BnfRule> sortedRules) {
     String superIntf = ObjectUtils.notNull(ContainerUtil.getFirstItem(getRootAttribute(myFile, KnownAttribute.IMPLEMENTS)),
                                            KnownAttribute.IMPLEMENTS.getDefaultValue().get(0)).second;
-    Set<String> imports = new LinkedHashSet<>(Arrays.asList("org.jetbrains.annotations.*", JavaBnfConstants.PSI_ELEMENT_VISITOR_CLASS, superIntf));
+    Set<String> imports = ContainerUtil.newLinkedHashSet("org.jetbrains.annotations.*", JavaBnfConstants.PSI_ELEMENT_VISITOR_CLASS, superIntf);
     MultiMap<String, String> supers = new MultiMap<>();
     for (BnfRule rule : sortedRules.values()) {
       supers.putValues(rule.getName(), getSuperInterfaceNames(myFile, rule, myPsiInterfaceFormat));
@@ -1685,7 +1685,7 @@ public final class JavaParserGenerator extends Generator {
         if (targetRule == null) {
           error = "'" + base + "' not found in '" + splitPath[i - 1] + "' (not a rule)";
         }
-        else if (available == null || available.isEmpty()) {
+        else if (ContainerUtil.isEmpty(available)) {
           error = "'" + base + "' not found in '" + targetRule.getName() + "' (available: nothing)";
         }
         else {

--- a/src/org/intellij/grammar/refactor/BnfIntroduceTokenHandler.java
+++ b/src/org/intellij/grammar/refactor/BnfIntroduceTokenHandler.java
@@ -251,7 +251,7 @@ public class BnfIntroduceTokenHandler implements RefactoringActionHandler {
       else {
         BnfExpression expression = tokensAttr.getExpression();
         List<BnfListEntry> entryList = expression instanceof BnfValueList ? ((BnfValueList) expression).getListEntryList() : null;
-        if (entryList == null || entryList.isEmpty()) {
+        if (ContainerUtil.isEmpty(entryList)) {
           tokensAttr = (BnfAttr)tokensAttr.replace(newAttr);
           BnfValueList attrExpr = (BnfValueList)Objects.requireNonNull(tokensAttr.getExpression());
           return attrExpr.getListEntryList().get(0);
@@ -265,7 +265,7 @@ public class BnfIntroduceTokenHandler implements RefactoringActionHandler {
           }
           BnfValueList attrExpr = (BnfValueList)Objects.requireNonNull(newAttr.getExpression());
           BnfListEntry newValue = attrExpr.getListEntryList().get(0);
-          PsiElement anchor = entryList.get(entryList.size() - 1);
+          PsiElement anchor = ContainerUtil.getLastItem(entryList);
           newValue = (BnfListEntry) expression.addAfter(newValue, anchor);
           expression.addAfter(BnfElementFactory.createLeafFromText(project, "\n    "), anchor);
           return newValue;


### PR DESCRIPTION
Replace hand-written null-or-empty checks, last-element access and the Arrays.asList set construction with ContainerUtil.isEmpty, getLastItem and newLinkedHashSet. KotlinParserGenerator already builds its import set with newLinkedHashSet.