### PR TITLE
bnf: fix slow keyword completion in grammars with 20+ rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Parser runtime: `DUMMY_BLOCK` now reuses the platform's `com.intellij.psi.DummyBlockType` instead of a private copy, and marker access goes through the `PsiBuilder.Marker` interface instead of downcasting to `PsiBuilderImpl`. `GeneratedParserUtilBase.DummyBlock` is deprecated for removal.
 * Parser runtime: `MAX_CHILDREN_IN_TREE`, the `DUMMY_BLOCK` chunk size, is now public, so tree-walking code no longer hardcodes it.
 * BNF completion: keyword and attribute completion now test dummy blocks against the platform's `DummyBlockType.DummyBlock`.
+* BNF completion: `getDummyAwarePrevSibling` now unwraps a `DUMMY_BLOCK` reached by climbing to a parent boundary, not just one found as a direct sibling, so keyword completion in grammars of twenty or more top-level items resumes after the last rule instead of re-parsing from the start of the file.
 * Generator: drop the unused annotation import that generated PSI impls picked up from an annotated superclass constructor.
 
 ## [2023.3.4]

--- a/bnf-language/src/org/intellij/grammar/psi/impl/GrammarUtil.java
+++ b/bnf-language/src/org/intellij/grammar/psi/impl/GrammarUtil.java
@@ -43,17 +43,24 @@ public class GrammarUtil {
 
   public static final BnfExpression[] EMPTY_EXPRESSIONS_ARRAY = new BnfExpression[0];
 
+  /**
+   * Previous sibling of {@code child} with {@code DUMMY_BLOCK} chunk nodes treated as transparent:
+   * a chunk in that position is unwrapped to the last child inside it, at any nesting depth, and a
+   * {@code child} that starts a chunk continues the search outside that chunk.
+   */
   public static PsiElement getDummyAwarePrevSibling(PsiElement child) {
     PsiElement prevSibling = child.getPrevSibling();
+    if (prevSibling == null) {
+      PsiElement parent = child.getParent();
+      while (parent instanceof DummyBlockType.DummyBlock && parent.getPrevSibling() == null) {
+        parent = parent.getParent();
+      }
+      prevSibling = parent == null ? null : parent.getPrevSibling();
+    }
     while (prevSibling instanceof DummyBlockType.DummyBlock) {
       prevSibling = prevSibling.getLastChild();
     }
-    if (prevSibling != null) return prevSibling;
-    PsiElement parent = child.getParent();
-    while (parent instanceof DummyBlockType.DummyBlock && parent.getPrevSibling() == null) {
-      parent = parent.getParent();
-    }
-    return parent == null ? null : parent.getPrevSibling();
+    return prevSibling;
   }
 
   public static boolean equalsElement(BnfExpression e1, BnfExpression e2) {

--- a/tests/org/intellij/grammar/GrammarUtilTest.java
+++ b/tests/org/intellij/grammar/GrammarUtilTest.java
@@ -13,12 +13,14 @@ import org.intellij.grammar.parser.GeneratedParserUtilBase;
 import org.intellij.grammar.psi.BnfRule;
 import org.intellij.grammar.psi.impl.GrammarUtil;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class GrammarUtilTest extends BasePlatformTestCase {
 
   public void testPrevSiblingDescendsIntoDummyBlock() {
-    PsiFile file = configureChunkedGrammar();
-    PsiElement trailing = file.getLastChild();
-    assertInstanceOf(trailing, PsiWhiteSpace.class);
+    PsiFile file = configureChunkedGrammar(GeneratedParserUtilBase.MAX_CHILDREN_IN_TREE);
+    PsiElement trailing = assertInstanceOf(file.getLastChild(), PsiWhiteSpace.class);
     // The parser builds the platform class; nothing instantiates GeneratedParserUtilBase.DummyBlock
     assertInstanceOf(trailing.getPrevSibling(), DummyBlockType.DummyBlock.class);
 
@@ -27,10 +29,28 @@ public class GrammarUtilTest extends BasePlatformTestCase {
     assertEquals("r" + (GeneratedParserUtilBase.MAX_CHILDREN_IN_TREE - 1), assertInstanceOf(prev, BnfRule.class).getName());
   }
 
-  /** Configures a grammar of exactly one chunk, so every top-level rule sits inside a {@code DUMMY_BLOCK}. */
-  private PsiFile configureChunkedGrammar() {
+  public void testPrevSiblingCrossesChunkBoundaries() {
+    int ruleCount = 2 * GeneratedParserUtilBase.MAX_CHILDREN_IN_TREE * GeneratedParserUtilBase.MAX_CHILDREN_IN_TREE;
+    PsiFile file = configureChunkedGrammar(ruleCount);
+    PsiElement trailing = assertInstanceOf(file.getLastChild(), PsiWhiteSpace.class);
+    // Enough rules that chunks nest, so the walk below crosses both a plain and a nested chunk start
+    assertInstanceOf(trailing.getPrevSibling().getLastChild(), DummyBlockType.DummyBlock.class);
+
+    List<String> visited = new ArrayList<>();
+    for (PsiElement cur = GrammarUtil.getDummyAwarePrevSibling(trailing); cur != null;
+         cur = GrammarUtil.getDummyAwarePrevSibling(cur)) {
+      if (cur instanceof BnfRule) visited.add(((BnfRule)cur).getName());
+    }
+
+    List<String> expected = new ArrayList<>();
+    for (int i = ruleCount - 1; i >= 0; i--) expected.add("r" + i);
+    assertEquals(expected, visited);
+  }
+
+  /** Configures a grammar of {@code ruleCount} rules, chunked into groups of {@link GeneratedParserUtilBase#MAX_CHILDREN_IN_TREE}. */
+  private PsiFile configureChunkedGrammar(int ruleCount) {
     StringBuilder text = new StringBuilder();
-    for (int i = 0; i < GeneratedParserUtilBase.MAX_CHILDREN_IN_TREE; i++) {
+    for (int i = 0; i < ruleCount; i++) {
       text.append("r").append(i).append(" ::= a;\n");
     }
     return myFixture.configureByText("a.bnf", text.toString());


### PR DESCRIPTION
Keyword completion in `.bnf` files with 20 or more top-level rules re-parsed the
file from the start on every completion request, instead of resuming after the
last preceding rule. Suggestions were still correct, just slower — and
increasingly so as the file grew. Fixed.